### PR TITLE
Fix check for existence of deep-chat

### DIFF
--- a/component/src/utils/HTTP/websocket.ts
+++ b/component/src/utils/HTTP/websocket.ts
@@ -21,7 +21,7 @@ export class Websocket {
   }
 
   public static createConnection(io: ServiceIO, messages: Messages) {
-    if (!document.body.contains(io.deepChat)) return; // check if element is still present
+    if (!(io.deepChat.getRootNode({composed: true}) instanceof Document)) return; // check if element is still present
     const websocketConfig = io.connectSettings.websocket;
     if (!websocketConfig) return;
     if (io.connectSettings.handler) return CustomHandler.websocket(io, messages);
@@ -47,7 +47,7 @@ export class Websocket {
 
   private static retryConnection(io: ServiceIO, messages: Messages) {
     io.deepChat._validationHandler?.();
-    if (!document.body.contains(io.deepChat)) return; // check if element is still present
+    if (!(io.deepChat.getRootNode({composed: true}) instanceof Document)) return; // check if element is still present
     io.websocket = 'pending';
     if (!messages.isLastMessageError()) messages.addNewErrorMessage('service', 'Connection error');
     setTimeout(() => {


### PR DESCRIPTION
`document.body.contains` cannot be used to check for the existence of the deep-chat node if it is inside of a shadow DOM (for example, if it is nested in another web component).  Instead, we can use `getRootNode` to check if the deep-chat node is attached to the document.

Fixes #193