### PR TITLE
feat: Update scrollToBottom and scrollToTop methods to allow smooth behaviour

### DIFF
--- a/component/src/utils/element/elementUtils.ts
+++ b/component/src/utils/element/elementUtils.ts
@@ -24,11 +24,11 @@ export class ElementUtils {
     return newElement;
   }
 
-  public static scrollToBottom(element: HTMLElement) {
-    element.scrollTop = element.scrollHeight;
+  public static scrollToBottom(element: HTMLElement, smooth: boolean = false) {
+    element.scrollTo({left: 0, top: element.scrollHeight, behavior: (smooth ? 'smooth' : 'instant')});
   }
 
-  public static scrollToTop(element: HTMLElement) {
-    element.scrollTop = 0;
+  public static scrollToTop(element: HTMLElement, smooth: boolean = false) {
+    element.scrollTo({left: 0, top: 0, behavior: (smooth ? 'smooth' : 'instant')});
   }
 }


### PR DESCRIPTION
Uses the [scrollTo()](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo) method instead of directly setting the scrollTop. By default, it will still scroll instantly. When passing `smooth = true`, it'll set the [behaviour](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo#behavior) to `smooth`.