### PR TITLE
fix(message): dont retain streamed message when clearMessage

### DIFF
--- a/component/src/views/chat/messages/messages.ts
+++ b/component/src/views/chat/messages/messages.ts
@@ -302,8 +302,7 @@ export class Messages extends MessagesBase {
       const bubbleClasslist = message.bubbleElement.classList;
       if (
         bubbleClasslist.contains(LoadingStyle.BUBBLE_CLASS) ||
-        bubbleClasslist.contains(LoadingHistory.CLASS) ||
-        bubbleClasslist.contains(MessageStream.MESSAGE_CLASS)
+        bubbleClasslist.contains(LoadingHistory.CLASS)
       ) {
         retainedElements.push(message);
       } else {


### PR DESCRIPTION
## Issue
Streamed message is retained upon `clearMessages`, or let me know this is an expected behaviour if i get it wrong 🙏 

## Fix
Exclude streamed message class from the class list

## Example
https://codesandbox.io/p/sandbox/deep-chat-reat-clear-msg-4p35fw?file=%2Fsrc%2FApp.js%3A23%2C11&workspaceId=78e86465-d41d-4807-b23f-8172fbc45cb1

1. Enter any message
2. Wait till the stream is over
3. Click the clear button
4. Notice the message from ai is not cleared

## Screenshot

https://github.com/user-attachments/assets/32e93857-bf2e-4888-90cb-829c45b9a3a3
