### PR TITLE
feat(submit-button): added enableSubmitButtonLoading & disableSubmitButtonLoading

### DIFF
--- a/component/custom-elements.json
+++ b/component/custom-elements.json
@@ -298,6 +298,21 @@
                 "text": "DisableSubmitButton"
               }
             },
+
+            {
+              "kind": "field",
+              "name": "enableSubmitButtonLoading",
+              "type": {
+                "text": "() => void"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "disableSubmitButtonLoading",
+              "type": {
+                "text": "() => void"
+              }
+            },
             {
               "kind": "field",
               "name": "setPlaceholderText",
@@ -40127,6 +40142,18 @@
                   }
                 }
               ]
+            },
+            {
+              "kind": "method",
+              "name": "enableSubmitButtonLoading",
+              "privacy": "private",
+              "parameters": []
+            },
+            {
+              "kind": "method",
+              "name": "disableSubmitButtonLoading",
+              "privacy": "private",
+              "parameters": []
             },
             {
               "kind": "field",

--- a/component/src/deepChat.ts
+++ b/component/src/deepChat.ts
@@ -157,6 +157,10 @@ export class DeepChat extends InternalHTML {
 
   disableSubmitButton: DisableSubmitButton = () => {};
 
+  enableSubmitButtonLoading: () => void = () => {};
+
+  disableSubmitButtonLoading: () => void = () => {};
+
   setPlaceholderText: (text: string) => void = () => {};
 
   @Property('function')

--- a/component/src/views/chat/input/buttons/submit/submitButton.ts
+++ b/component/src/views/chat/input/buttons/submit/submitButton.ts
@@ -60,6 +60,8 @@ export class SubmitButton extends InputButton<Styles> {
     this._serviceIO = serviceIO;
     this._alwaysEnabled = !!submitButtonStyles?.alwaysEnabled;
     deepChat.disableSubmitButton = this.disableSubmitButton.bind(this, serviceIO);
+    deepChat.enableSubmitButtonLoading = this.enableSubmitButtonLoading.bind(this);
+    deepChat.disableSubmitButtonLoading = this.disableSubmitButtonLoading.bind(this);
     this.attemptOverwriteLoadingStyle(deepChat);
     if (buttons.microphone) this.setUpSpeechToText(buttons.microphone.button, deepChat.speechToText);
     setTimeout(() => { // in a timeout as deepChat._validationHandler initialised later
@@ -271,6 +273,19 @@ export class SubmitButton extends InputButton<Styles> {
       this._validationHandler?.();
     } else {
       this.changeToDisabledIcon(true);
+    }
+  }
+
+  private enableSubmitButtonLoading() {
+    if (!this.status.loadingActive) {
+      this.changeToLoadingIcon();
+    }
+  }
+
+  private disableSubmitButtonLoading() {
+    if (this.status.loadingActive) {
+      this.resetSubmit(() => Promise.resolve(null));
+      this.changeToSubmitIcon();
     }
   }
 }

--- a/website/docs/docs/methods.mdx
+++ b/website/docs/docs/methods.mdx
@@ -289,6 +289,54 @@ chatElementRef.disableSubmitButton();
 
 <LineBreak></LineBreak>
 
+### `enableSubmitButtonLoading` {#enableSubmitButtonLoading}
+
+- Type: (`override?: boolean`) => `void`
+
+Applies loading styles to the confirmation button.
+
+#### Example
+
+<ComponentContainerMethods propertyName={'enableSubmitButtonLoading'} displayResults={false}>
+  <DeepChatBrowser style={{borderRadius: '8px'}} demo={true}></DeepChatBrowser>
+</ComponentContainerMethods>
+
+<Tabs>
+<TabItem value="js" label="Code">
+
+```html
+chatElementRef.enableSubmitButtonLoading();
+```
+
+</TabItem>
+</Tabs>
+
+<LineBreak></LineBreak>
+
+### `disableSubmitButtonLoading` {#disableSubmitButtonLoading}
+
+- Type: (`override?: boolean`) => `void`
+
+Removes loading styles to the confirmation button and applies default styles.
+
+#### Example
+
+<ComponentContainerMethods propertyName={'disableSubmitButtonLoading'} displayResults={false}>
+  <DeepChatBrowser style={{borderRadius: '8px'}} demo={true}></DeepChatBrowser>
+</ComponentContainerMethods>
+
+<Tabs>
+<TabItem value="js" label="Code">
+
+```html
+chatElementRef.disableSubmitButtonLoading();
+```
+
+</TabItem>
+</Tabs>
+
+<LineBreak></LineBreak>
+
 ### `refreshMessages` {#refreshMessages}
 
 - Type: `() => void`

--- a/website/docs/docs/styles.mdx
+++ b/website/docs/docs/styles.mdx
@@ -412,6 +412,7 @@ Custom details for the chat's text input. <br />
 Custom styling for the submit button. <br />
 `submit` state is displayed when the user's input is valid and can be sent. <br />
 `loading` is used when waiting for a message response from the target server. <br />
+You can also set this state manually by calling the [`enableSubmitButtonLoading`](/docs/methods#enableSubmitButtonLoading) method and then revert manually by calling the [`disableSubmitButtonLoading`](/docs/methods#disableSubmitButtonLoading) method. <br />
 `stop` is used when a message response is being [`streamed`](/docs/connect#Stream). <br />
 `disabled` is used when the user's input cannot be sent (see [`validateInput`](/docs/interceptors#validateInput)) or the [websocket](/docs/connect#Websocket) connection is not live.
 You can also set this state manually by calling the [`disableSubmitButton`](/docs/methods#disableSubmitButton) method. <br />


### PR DESCRIPTION
I added two simple methods: `enableSubmitButtonLoading` and `disableSubmitButtonLoading`.
Therefore, now it's possible to programmatically set submit button state to loading or from loading to default.