### PR TITLE
Azure OpenAI Assistants API support

### DIFF
--- a/component/index.html
+++ b/component/index.html
@@ -24,34 +24,7 @@
       to properties must not have external references and all regex values are properly escaped.
       You can also pass values into the component via properties by using the element reference (history).
       -->
-    <deep-chat
-      id="chat-element"
-      directConnection='{
-        "azureOpenAI": {
-          "key": "d97bb611709d48a9b0a860c3d35fb43f",
-          "validateKeyProperty": true,
-          "azureConfig": {
-            "endpoint": "https://jacktestaoai.openai.azure.com/openai",
-            "version": "2024-05-01-preview"
-          },
-          "assistant": {
-            "new_assistant": {
-              "model": "gpt-4o-mini",
-              "name": "Test Azure Assistant",
-              "description": "An assistant to test Azure integration into deep-chat",
-              "instructions": "You are an assistant. Your instructions are to help test the integration of Azure with deep-chat",
-              "tools": [
-                { "type": "code_interpreter" },
-                { "type": "file_search" }
-              ]
-            },
-            "files_tool_type": "code_interpreter"
-          }
-        }
-      }'
-      mixedFiles="true"
-      dragAndDrop="true"
-    ></deep-chat>
+    <deep-chat id="chat-element" demo="true" textInput='{"placeholder":{"text": "Welcome to the demo!"}}'></deep-chat>
     <script type="module">
       const chatElementRef = document.getElementById('chat-element');
       // Setting value via a property (easiest way)

--- a/component/index.html
+++ b/component/index.html
@@ -24,7 +24,34 @@
       to properties must not have external references and all regex values are properly escaped.
       You can also pass values into the component via properties by using the element reference (history).
       -->
-    <deep-chat id="chat-element" demo="true" textInput='{"placeholder":{"text": "Welcome to the demo!"}}'></deep-chat>
+    <deep-chat
+      id="chat-element"
+      directConnection='{
+        "azureOpenAI": {
+          "key": "d97bb611709d48a9b0a860c3d35fb43f",
+          "validateKeyProperty": true,
+          "azureConfig": {
+            "endpoint": "https://jacktestaoai.openai.azure.com/openai",
+            "version": "2024-05-01-preview"
+          },
+          "assistant": {
+            "new_assistant": {
+              "model": "gpt-4o-mini",
+              "name": "Test Azure Assistant",
+              "description": "An assistant to test Azure integration into deep-chat",
+              "instructions": "You are an assistant. Your instructions are to help test the integration of Azure with deep-chat",
+              "tools": [
+                { "type": "code_interpreter" },
+                { "type": "file_search" }
+              ]
+            },
+            "files_tool_type": "code_interpreter"
+          }
+        }
+      }'
+      mixedFiles="true"
+      dragAndDrop="true"
+    ></deep-chat>
     <script type="module">
       const chatElementRef = document.getElementById('chat-element');
       // Setting value via a property (easiest way)

--- a/component/src/services/azureOpenAI/azureOpenAIAssistantIO.ts
+++ b/component/src/services/azureOpenAI/azureOpenAIAssistantIO.ts
@@ -1,0 +1,381 @@
+import {AssistantFunctionHandler, AzureConfig, AzureOpenAIAssistant, AzureOpenAINewAssistant} from '../../types/azureOpenAI';
+import {AzureOpenAIAssistantUtils, UploadedFile} from './utils/azureOpenAIAssistantUtils';
+import {MessageStream} from '../../views/chat/messages/stream/messageStream';
+import {FileMessageUtils} from '../../views/chat/messages/fileMessageUtils';
+import {OpenAIConverseBodyInternal} from '../../types/openAIInternal';
+import {DirectConnection} from '../../types/directConnection';
+import {MessageLimitUtils} from '../utils/messageLimitUtils';
+import {MessageContentI} from '../../types/messagesInternal';
+import {Messages} from '../../views/chat/messages/messages';
+import {Response as ResponseI} from '../../types/response';
+import {HTTPRequest} from '../../utils/HTTP/HTTPRequest';
+import {DirectServiceIO} from '../utils/directServiceIO';
+import {AzureOpenAIUtils} from './utils/azureOpenAIUtils';
+import {Stream} from '../../utils/HTTP/stream';
+import {DeepChat} from '../../deepChat';
+import {PollResult} from '../serviceIO';
+import {
+  OpenAIAssistantMessagesResult,
+  OpenAIAssistantInitReqResult,
+  OpenAINewAssistantResult,
+  OpenAIRunResult,
+  ToolCalls,
+} from '../../types/openAIResult';
+
+// https://platform.openai.com/docs/api-reference/messages/createMessage
+type MessageContentArr = {
+  type: string;
+  image_file?: {
+    file_id: string;
+  };
+  text?: string;
+}[];
+
+type FileAttachments = {
+  file_id: string;
+  tools: {type: AzureOpenAIAssistant['files_tool_type']}[];
+}[];
+
+export class AzureOpenAIAssistantIO extends DirectServiceIO {
+  override insertKeyPlaceholderText = 'OpenAI API Key';
+  override keyHelpUrl = 'https://platform.openai.com/account/api-keys';
+  url = ''; // set dynamically
+  private static readonly THREAD_RESOURCE = `threads`;
+  private static readonly NEW_ASSISTANT_RESOURCE = 'assistants';
+  private static readonly POLLING_TIMEOUT_MS = 800;
+  private readonly _functionHandler?: AssistantFunctionHandler;
+  permittedErrorPrefixes = ['Incorrect', 'Please send text'];
+  private messages?: Messages;
+  private run_id?: string;
+  private searchedForThreadId = false;
+  private readonly config: AzureOpenAIAssistant = {};
+  private readonly newAssistantDetails: AzureOpenAINewAssistant = {model: 'gpt-4'};
+  private readonly shouldFetchHistory: boolean = false;
+  private waitingForStreamResponse = false;
+  private readonly isSSEStream: boolean = false;
+  private messageStream: MessageStream | undefined;
+  private readonly filesToolType: AzureOpenAIAssistant['files_tool_type'];
+  private readonly azureConfig: AzureConfig;
+  fetchHistory?: () => Promise<ResponseI[]>;
+
+  constructor(deepChat: DeepChat) {
+    const directConnectionCopy = JSON.parse(JSON.stringify(deepChat.directConnection)) as DirectConnection;
+    const apiKey = directConnectionCopy.azureOpenAI;
+
+    if (!directConnectionCopy.azureOpenAI?.azureConfig) {
+      throw Error("Azure OpenAI endpoint not defined")
+    }
+
+    const azureConfig = directConnectionCopy.azureOpenAI?.azureConfig;
+
+    super(deepChat, AzureOpenAIUtils.buildKeyVerificationDetails(azureConfig), AzureOpenAIUtils.buildHeaders, apiKey);
+
+    this.azureConfig = azureConfig;
+    const config = directConnectionCopy.azureOpenAI?.assistant; // can be undefined as this is the default service
+    if (typeof config === 'object') {
+      this.config = config; // stored that assistant_id could be added
+      const {new_assistant, thread_id, load_thread_history} = this.config;
+      Object.assign(this.newAssistantDetails, new_assistant);
+      if (thread_id) this.sessionId = thread_id;
+      if (load_thread_history) this.shouldFetchHistory = true;
+      const {function_handler} = deepChat.directConnection?.azureOpenAI?.assistant as AzureOpenAIAssistant;
+      if (function_handler) this._functionHandler = function_handler;
+      this.filesToolType = config.files_tool_type;
+    } else if (directConnectionCopy.azureOpenAI?.assistant) {
+      directConnectionCopy.azureOpenAI.assistant = config;
+    }
+    this.connectSettings.headers ??= {};
+    this.maxMessages = 1; // messages are stored in OpenAI threads and can't create new thread with 'assistant' messages
+    this.isSSEStream = Boolean(this.stream && (typeof this.stream !== 'object' || !this.stream.simulation));
+    if (this.shouldFetchHistory && this.sessionId) this.fetchHistory = this.fetchHistoryFunc.bind(this);
+  }
+
+  private async fetchHistoryFunc() {
+    setTimeout(() => this.deepChat.disableSubmitButton(), 2); // not initialised when fetchHistoryFunc called
+    try {
+      const threadMessages = await this.getThreadMessages(this.sessionId as string, true);
+      this.deepChat.disableSubmitButton(false);
+      return threadMessages;
+    } catch (e) {
+      return [{error: 'failed to fetch thread history'}];
+    }
+  }
+
+  private static processImageMessage(processedMessage: MessageContentI, uploadedFiles?: UploadedFile[]) {
+    const contentArr: MessageContentArr | undefined = uploadedFiles
+      ?.filter((file) => FileMessageUtils.isImageFileExtension(file.name))
+      .map((file) => {
+        return {type: 'image_file', image_file: {file_id: file.id}};
+      });
+    if (contentArr && contentArr.length > 0) {
+      if (processedMessage.text && processedMessage.text.length > 0) {
+        contentArr.push({type: 'text', text: processedMessage.text});
+      }
+      return {content: contentArr, role: 'user'};
+    }
+    return undefined;
+  }
+
+  private static processAttachmentsMessage(
+    processedMessage: MessageContentI,
+    uploadedFiles: UploadedFile[],
+    toolType: AzureOpenAIAssistant['files_tool_type']
+  ) {
+    const attachments: FileAttachments = uploadedFiles.map((file) => {
+      return {tools: [{type: toolType}], file_id: file.id};
+    });
+    return {attachments, content: [{type: 'text', text: processedMessage.text}], role: 'user'};
+  }
+
+  private processMessage(pMessages: MessageContentI[], uploadedFiles?: UploadedFile[]) {
+    const totalMessagesMaxCharLength = this.totalMessagesMaxCharLength || -1;
+    // pMessages only conytains one message due to maxMessages being set to 1
+    const processedMessage = MessageLimitUtils.getCharacterLimitMessages(pMessages, totalMessagesMaxCharLength)[0];
+    // https://platform.openai.com/docs/api-reference/messages/createMessage
+    if (uploadedFiles && uploadedFiles.length > 0) {
+      let toolType = this.filesToolType;
+      // OpenAI also allows multiple tool types for a message but not doing it here as we don't process multiple responses.
+      // https://platform.openai.com/docs/assistants/migration/what-has-changed
+      // "tools": [
+      //   { "type": "file_search" },
+      //   { "type": "code_interpreter" }
+      // ]
+      if (typeof this.filesToolType === 'function') {
+        const rToolType = this.filesToolType(uploadedFiles.map(({name}) => name));
+        if (rToolType === 'code_interpreter' || rToolType === 'file_search' || rToolType === 'images') {
+          toolType = rToolType;
+        } else {
+          console.error(`Tool type "${rToolType}" is not valid`);
+          console.error('Expected "code_interpreter" or "file_search" or "images". Going to default to "images"');
+        }
+      }
+      if (toolType === 'file_search') {
+        return AzureOpenAIAssistantIO.processAttachmentsMessage(processedMessage, uploadedFiles, 'file_search');
+      }
+      if (toolType === 'code_interpreter') {
+        return AzureOpenAIAssistantIO.processAttachmentsMessage(processedMessage, uploadedFiles, 'code_interpreter');
+      }
+      const notImage = uploadedFiles.find(({name}) => !FileMessageUtils.isImageFileExtension(name));
+      if (notImage) {
+        console.error('The uploaded files contained a non-image file');
+        console.error(
+          'Make sure only images can be uploaded or define a "code_interpreter" or "file_search"' +
+            ' value in the "files_tool_type" property'
+        );
+        console.warn(
+          'Make sure your existing assistant supports these "tools" or specify them in the "new_assistant" property'
+        );
+      } else {
+        const imageMessage = AzureOpenAIAssistantIO.processImageMessage(processedMessage, uploadedFiles);
+        if (imageMessage) return imageMessage;
+      }
+    }
+    return {content: processedMessage.text || '', role: 'user'};
+  }
+
+  private createNewThreadMessages(body: OpenAIConverseBodyInternal, pMessages: MessageContentI[], files?: UploadedFile[]) {
+    const bodyCopy = JSON.parse(JSON.stringify(body));
+    const processedMessage = this.processMessage(pMessages, files);
+    bodyCopy.thread = {messages: [processedMessage]};
+    return bodyCopy;
+  }
+
+  private callService(messages: Messages, pMessages: MessageContentI[], uploadedFiles?: UploadedFile[]) {
+    this.messages = messages;
+    if (this.sessionId) {
+      // https://platform.openai.com/docs/api-reference/messages/createMessage
+      this.url = `${this.azureConfig.endpoint}/openai/${AzureOpenAIAssistantIO.THREAD_RESOURCE}/${this.sessionId}/messages?order=desc&api-version=${this.azureConfig.version}`;
+      const body = this.processMessage(pMessages, uploadedFiles);
+      HTTPRequest.request(this, body, messages);
+    } else {
+      // https://platform.openai.com/docs/api-reference/runs/createThreadAndRun
+      this.url = `${this.azureConfig.endpoint}/openai/${AzureOpenAIAssistantIO.THREAD_RESOURCE}/runs?api-version=${this.azureConfig.version}`;
+      const body = this.createNewThreadMessages(this.rawBody, pMessages, uploadedFiles);
+      if (this.isSSEStream) {
+        this.createStreamRun(body);
+      } else {
+        HTTPRequest.request(this, body, messages);
+      }
+    }
+  }
+
+  override async callServiceAPI(messages: Messages, pMessages: MessageContentI[], files?: File[]) {
+    this.waitingForStreamResponse = false;
+    if (!this.connectSettings) throw new Error('Request settings have not been set up');
+    this.rawBody.assistant_id ??= this.config.assistant_id || (await this.createNewAssistant());
+    // here instead of constructor as messages may be loaded later
+    if (!this.searchedForThreadId) this.searchPreviousMessagesForThreadId(messages.messages);
+    const uploadedFiles = files ? await AzureOpenAIAssistantUtils.storeFiles(this, this.azureConfig, messages, files) : undefined;
+    this.connectSettings.method = 'POST';
+    this.callService(messages, pMessages, uploadedFiles);
+  }
+
+  private async createNewAssistant() {
+    try {
+      this.url = `${this.azureConfig.endpoint}/openai/${AzureOpenAIAssistantIO.NEW_ASSISTANT_RESOURCE}?api-version=${this.azureConfig.version}`;
+      const result = await AzureOpenAIUtils.directFetch(this, JSON.parse(JSON.stringify(this.newAssistantDetails)), 'POST');
+      this.config.assistant_id = (result as OpenAINewAssistantResult).id;
+      return this.config.assistant_id;
+    } catch (e) {
+      console.error(e);
+      console.error('Failed to create a new assistant'); // letting later calls throw and handle error
+    }
+    return undefined;
+  }
+
+  private searchPreviousMessagesForThreadId(messages: MessageContentI[]) {
+    const messageWithSession = messages.find((message) => message._sessionId);
+    if (messageWithSession) this.sessionId = messageWithSession._sessionId;
+    this.searchedForThreadId = true;
+  }
+
+  // prettier-ignore
+  override async extractResultData(result: OpenAIAssistantInitReqResult):
+      Promise<ResponseI | {makingAnotherRequest: true}> {
+    if (this.waitingForStreamResponse || (this.isSSEStream && this.sessionId)) {
+      return await this.handleStream(result);
+    }
+    if (result.error) {
+      if (result.error.message.startsWith(AzureOpenAIAssistantUtils.FILES_WITH_TEXT_ERROR)) {
+        throw Error('Please send text with your file(s)');
+      }
+      throw result.error.message;
+    }
+    await this.assignThreadAndRun(result);
+    // https://platform.openai.com/docs/api-reference/runs/getRun
+    const url = `${this.azureConfig.endpoint}/openai/${AzureOpenAIAssistantIO.THREAD_RESOURCE}/${this.sessionId}/runs/${this.run_id}?api-version=${this.azureConfig.version}`;
+    const requestInit = {method: 'GET', headers: this.connectSettings?.headers};
+    HTTPRequest.executePollRequest(this, url, requestInit, this.messages as Messages); // poll for run status
+    return {makingAnotherRequest: true};
+  }
+
+  private async assignThreadAndRun(result: OpenAIAssistantInitReqResult) {
+    if (this.sessionId) {
+      // https://platform.openai.com/docs/api-reference/runs/createRun
+      this.url = `${this.azureConfig.endpoint}/openai/${AzureOpenAIAssistantIO.THREAD_RESOURCE}/${this.sessionId}/runs?api-version=${this.azureConfig.version}`;
+      const runObj = await AzureOpenAIUtils.directFetch(this, JSON.parse(JSON.stringify(this.rawBody)), 'POST');
+      this.run_id = runObj.id;
+    } else {
+      this.sessionId = result.thread_id;
+      this.run_id = result.id;
+      // updates the user sent message with the session id (the message event sent did not have this id)
+      if (this.messages) this.messages.messages[this.messages.messages.length - 1]._sessionId = this.sessionId;
+    }
+  }
+
+  private async getThreadMessages(thread_id: string, isHistory = false) {
+    // https://platform.openai.com/docs/api-reference/messages/listMessages
+    this.url = `${this.azureConfig.endpoint}/openai/${AzureOpenAIAssistantIO.THREAD_RESOURCE}/${thread_id}/messages?api-version=${this.azureConfig.version}`;
+    let threadMessages = (await AzureOpenAIUtils.directFetch(this, {}, 'GET')) as OpenAIAssistantMessagesResult;
+    if (!isHistory && this.deepChat.responseInterceptor) {
+      threadMessages = (await this.deepChat.responseInterceptor?.(threadMessages)) as OpenAIAssistantMessagesResult;
+    }
+    return AzureOpenAIAssistantUtils.processAPIMessages(this, this.azureConfig, threadMessages, isHistory);
+  }
+
+  async extractPollResultData(result: OpenAIRunResult): PollResult {
+    const {status, required_action} = result;
+    if (status === 'queued' || status === 'in_progress') return {timeoutMS: AzureOpenAIAssistantIO.POLLING_TIMEOUT_MS};
+    if (status === 'completed' && this.messages) {
+      const threadMessages = await this.getThreadMessages(result.thread_id);
+      const {text, files} = threadMessages.shift() as ResponseI;
+      setTimeout(() => {
+        threadMessages.forEach((message) => this.deepChat.addMessage(message));
+      });
+      return {text, _sessionId: this.sessionId, files};
+    }
+    const toolCalls = required_action?.submit_tool_outputs?.tool_calls;
+    if (status === 'requires_action' && toolCalls) {
+      return await this.handleTools(toolCalls);
+    }
+    throw Error(`Thread run status: ${status}`);
+  }
+
+  // prettier-ignore
+  private async handleTools(toolCalls: ToolCalls): PollResult {
+    if (!this._functionHandler) {
+      throw Error(
+        'Please define the `function_handler` property inside' +
+          ' the [openAI](https://deepchat.dev/docs/directConnection/openAI#Assistant) object.'
+      );
+    }
+    const functions = toolCalls.map((call) => {
+      return {name: call.function.name, arguments: call.function.arguments};
+    });
+    const handlerResponse = this._functionHandler(functions);
+    if (!Array.isArray(handlerResponse) || toolCalls.length !== handlerResponse.length) {
+      throw Error(AzureOpenAIAssistantUtils.FUNCTION_TOOL_RESP_ERROR);
+    }
+    const invidualResponses = await Promise.all(handlerResponse);
+    if (invidualResponses.find((response) => typeof response !== 'string')) {
+      throw Error(AzureOpenAIAssistantUtils.FUNCTION_TOOL_RESP_ERROR);
+    }
+    const tool_outputs = invidualResponses.map((resp, index) => {
+      return {tool_call_id: toolCalls[index].id, output: resp};
+    });
+    // https://platform.openai.com/docs/api-reference/runs/submitToolOutputs
+    this.url = `${this.azureConfig.endpoint}/openai/${AzureOpenAIAssistantIO.THREAD_RESOURCE}/${this.sessionId}/runs/${this.run_id}/submit_tool_outputs?api-version=${this.azureConfig.version}`;
+    if (this.isSSEStream) {
+      await this.createStreamRun({tool_outputs});
+    } else {
+      await AzureOpenAIUtils.directFetch(this, {tool_outputs}, 'POST');
+    }
+    return {timeoutMS: AzureOpenAIAssistantIO.POLLING_TIMEOUT_MS};
+  }
+
+  private async handleStream(result: OpenAIAssistantInitReqResult) {
+    const toolCalls = result.required_action?.submit_tool_outputs?.tool_calls;
+    if (result.status === 'requires_action' && toolCalls) {
+      this.run_id = result.id;
+      return await this.handleTools(toolCalls);
+    }
+    if (this.waitingForStreamResponse) {
+      return this.parseStreamResult(result);
+    }
+    if (this.isSSEStream && this.sessionId) {
+      // https://platform.openai.com/docs/api-reference/runs/createRun
+      this.url = `${this.azureConfig.endpoint}/openai/${AzureOpenAIAssistantIO.THREAD_RESOURCE}/${this.sessionId}/runs?api-version=${this.azureConfig.version}`;
+      const newBody = JSON.parse(JSON.stringify(this.rawBody));
+      this.createStreamRun(newBody);
+    }
+    return {makingAnotherRequest: true};
+  }
+
+  // prettier-ignore
+  private async parseStreamResult(result: OpenAIAssistantInitReqResult) {
+    if (result.content && result.content.length > 0 && this.messages) {
+      // if file is included and there is an annotation/link in text, process at the end
+      const textContent = result.content.find((content) => content.text);
+      if (textContent?.text?.annotations && textContent.text.annotations.length > 0) {
+        const textFileFirst = result.content.find((content) => !!content.text) || result.content[0];
+        const downloadCb = AzureOpenAIAssistantUtils.getFilesAndText.bind(this,
+          this, this.azureConfig, {role: 'assistant', content: result.content}, textFileFirst);
+        this.messageStream?.endStreamAfterFileDownloaded(this.messages, downloadCb);
+        return {text: ''};
+      }
+    }
+    if (result.delta?.content) {
+      if (result.delta.content.length > 1) {
+        // if file is included and there is no annotation/link in text, process during the stream
+        const textContent = result.delta.content.find((content) => content.text);
+        if (textContent?.text?.annotations && textContent.text.annotations.length === 0) {
+          const messages = await AzureOpenAIAssistantUtils.processStreamMessages(this, this.azureConfig, result.delta.content);
+          return {text: messages[0].text, files: messages[1].files};
+        }
+      }
+      return {text: result.delta.content[0].text?.value};
+    }
+    if (!this.sessionId && result.thread_id) {
+      this.sessionId = result.thread_id;
+    }
+    return {makingAnotherRequest: true};
+  }
+
+  // https://platform.openai.com/docs/api-reference/assistants-streaming
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async createStreamRun(body: any) {
+    body.stream = true;
+    this.waitingForStreamResponse = true;
+    this.messageStream = (await Stream.request(this, body, this.messages as Messages, true, true)) as MessageStream;
+  }
+}

--- a/component/src/services/azureOpenAI/azureOpenAIChatIO.ts
+++ b/component/src/services/azureOpenAI/azureOpenAIChatIO.ts
@@ -1,0 +1,187 @@
+import {OpenAIConverseResult, ResultChoice, ToolAPI, ToolCalls} from '../../types/openAIResult';
+import {OpenAIConverseBodyInternal, SystemMessageInternal} from '../../types/openAIInternal';
+import {FetchFunc, RequestUtils} from '../../utils/HTTP/requestUtils';
+import {MessageUtils} from '../../views/chat/messages/messageUtils';
+import {ChatFunctionHandler, AzureOpenAIChat, AzureConfig} from '../../types/azureOpenAI';
+import {DirectConnection} from '../../types/directConnection';
+import {MessageLimitUtils} from '../utils/messageLimitUtils';
+import {MessageContentI} from '../../types/messagesInternal';
+import {Messages} from '../../views/chat/messages/messages';
+import {Response as ResponseI} from '../../types/response';
+import {HTTPRequest} from '../../utils/HTTP/HTTPRequest';
+import {DirectServiceIO} from '../utils/directServiceIO';
+import {AzureOpenAIUtils} from './utils/azureOpenAIUtils';
+import {Stream} from '../../utils/HTTP/stream';
+import {DeepChat} from '../../deepChat';
+
+type ImageContent = {type: string; image_url?: {url?: string}; text?: string}[];
+
+export class AzureOpenAIChatIO extends DirectServiceIO {
+  override insertKeyPlaceholderText = 'OpenAI API Key';
+  override keyHelpUrl = 'https://platform.openai.com/account/api-keys';
+  url = ''; // set in constructor
+  permittedErrorPrefixes = ['Incorrect'];
+  private readonly _functionHandler?: ChatFunctionHandler;
+  private _streamToolCalls?: ToolCalls;
+  asyncCallInProgress = false; // used when streaming tools
+  private readonly _systemMessage: SystemMessageInternal =
+    AzureOpenAIChatIO.generateSystemMessage('You are a helpful assistant.');
+
+  constructor(deepChat: DeepChat) {
+    const directConnectionCopy = JSON.parse(JSON.stringify(deepChat.directConnection)) as DirectConnection;
+    const apiKey = directConnectionCopy.azureOpenAI;
+
+    if (!directConnectionCopy.azureOpenAI?.azureConfig) {
+      throw Error("Azure OpenAI endpoint not defined")
+    }
+
+    const azureConfig: AzureConfig = directConnectionCopy.azureOpenAI?.azureConfig;
+
+    super(deepChat, AzureOpenAIUtils.buildKeyVerificationDetails(azureConfig), AzureOpenAIUtils.buildHeaders, apiKey);
+
+    // need to call super before accessing this
+    this.url= `${azureConfig.endpoint}/openai/deployments/${azureConfig.deploymentId}/completions?api-version=${azureConfig.version}`;
+
+    const config = directConnectionCopy.azureOpenAI?.chat; // can be undefined as this is the default service
+    if (typeof config === 'object') {
+      if (config.system_prompt) this._systemMessage = AzureOpenAIChatIO.generateSystemMessage(config.system_prompt);
+      const {function_handler} = deepChat.directConnection?.azureOpenAI?.chat as AzureOpenAIChat;
+      if (function_handler) this._functionHandler = function_handler;
+      this.cleanConfig(config);
+      Object.assign(this.rawBody, config);
+    }
+    this.maxMessages ??= -1;
+    this.rawBody.model ??= 'gpt-4o';
+  }
+
+  private static generateSystemMessage(system_prompt: string): SystemMessageInternal {
+    return {role: 'system', content: system_prompt};
+  }
+
+  private cleanConfig(config: AzureOpenAIChat) {
+    delete config.system_prompt;
+    delete config.function_handler;
+  }
+
+  private static getContent(message: MessageContentI) {
+    if (message.files && message.files.length > 0) {
+      const content: ImageContent = message.files.map((file) => {
+        return {type: 'image_url', image_url: {url: file.src}};
+      });
+      if (message.text && message.text.trim().length > 0) content.unshift({type: 'text', text: message.text});
+      return content;
+    }
+    return message.text;
+  }
+
+  // prettier-ignore
+  private preprocessBody(body: OpenAIConverseBodyInternal, pMessages: MessageContentI[]) {
+    const bodyCopy = JSON.parse(JSON.stringify(body));
+    const processedMessages = MessageLimitUtils.getCharacterLimitMessages(pMessages,
+        this.totalMessagesMaxCharLength ? this.totalMessagesMaxCharLength - this._systemMessage.content.length : -1)
+      .map((message) => {
+        return {content: AzureOpenAIChatIO.getContent(message),
+          role: message.role === MessageUtils.USER_ROLE ? 'user' : 'assistant'};});
+    if (pMessages.find((message) => message.files && message.files.length > 0)) {
+      bodyCopy.max_tokens ??= 300; // otherwise AI does not return full responses - remove when this behaviour changes
+    }
+    bodyCopy.messages = [this._systemMessage, ...processedMessages];
+    return bodyCopy;
+  }
+
+  override async callServiceAPI(messages: Messages, pMessages: MessageContentI[]) {
+    if (!this.connectSettings) throw new Error('Request settings have not been set up');
+    const body = this.preprocessBody(this.rawBody, pMessages);
+    const stream = this.stream;
+    if ((stream && (typeof stream !== 'object' || !stream.simulation)) || body.stream) {
+      body.stream = true;
+      Stream.request(this, body, messages);
+    } else {
+      HTTPRequest.request(this, body, messages);
+    }
+  }
+
+  // prettier-ignore
+  override async extractResultData(result: OpenAIConverseResult,
+      fetchFunc?: FetchFunc, prevBody?: AzureOpenAIChat): Promise<ResponseI> {
+    if (result.error) throw result.error.message;
+    if (result.choices?.[0]?.delta) {
+      return this.extractStreamResult(result.choices[0], fetchFunc, prevBody);
+    }
+    if (result.choices?.[0]?.message) {
+      if (result.choices[0].message.tool_calls) {
+        return this.handleTools(result.choices[0].message, fetchFunc, prevBody);
+      }
+      return {text: result.choices[0].message.content};
+    }
+    return {text: ''};
+  }
+
+  private async extractStreamResult(choice: ResultChoice, fetchFunc?: FetchFunc, prevBody?: AzureOpenAIChat) {
+    const {delta, finish_reason} = choice;
+    if (finish_reason === 'tool_calls') {
+      this.asyncCallInProgress = true;
+      const tools = {tool_calls: this._streamToolCalls};
+      this._streamToolCalls = undefined;
+      return this.handleTools(tools, fetchFunc, prevBody);
+    } else if (delta?.tool_calls) {
+      if (!this._streamToolCalls) {
+        this._streamToolCalls = delta.tool_calls;
+      } else {
+        delta.tool_calls.forEach((tool, index) => {
+          if (this._streamToolCalls) this._streamToolCalls[index].function.arguments += tool.function.arguments;
+        });
+      }
+    }
+    return {text: delta?.content || ''};
+  }
+
+  // prettier-ignore
+  private async handleTools(tools: ToolAPI, fetchFunc?: FetchFunc, prevBody?: AzureOpenAIChat): Promise<ResponseI> {
+    // tool_calls, requestFunc and prevBody should theoretically be defined
+    if (!tools.tool_calls || !fetchFunc || !prevBody || !this._functionHandler) {
+      throw Error(
+        'Please define the `function_handler` property inside' +
+          ' the [openAI](https://deepchat.dev/docs/directConnection/openAI#Chat) object.'
+      );
+    }
+    const bodyCp = JSON.parse(JSON.stringify(prevBody));
+    const functions = tools.tool_calls.map((call) => {
+      return {name: call.function.name, arguments: call.function.arguments};
+    });
+    const handlerResponse = await this._functionHandler?.(functions);
+    if (handlerResponse.text) {
+      const response = {text: handlerResponse.text};
+      return await this.deepChat.responseInterceptor?.(response) || response;
+    }
+    bodyCp.messages.push({tool_calls: tools.tool_calls, role: 'assistant', content: null});
+    if ((Array.isArray(handlerResponse) && !handlerResponse.find((response) => typeof response !== 'string'))
+        || functions.length === handlerResponse.length) {
+      handlerResponse.forEach((resp, index) => {
+        const toolCall = tools.tool_calls?.[index];
+        bodyCp?.messages.push({
+          role: 'tool',
+          tool_call_id: toolCall?.id,
+          name: toolCall?.function.name,
+          content: resp.response,
+        });
+      });
+      delete bodyCp.tools;
+      delete bodyCp.tool_choice;
+      delete bodyCp.stream;
+      try {
+        let result = await fetchFunc?.(bodyCp).then((resp) => RequestUtils.processResponseByType(resp));
+        result = await this.deepChat.responseInterceptor?.(result) || result;
+        if (result.error) throw result.error.message;
+        return {text: result.choices[0].message.content || ''};
+      } catch (e) {
+        this.asyncCallInProgress = false;
+        throw e;
+      }
+    }
+    throw Error(
+      'Response object must either be {response: string}[] for each individual function ' +
+        'or {text: string} for a direct response, see https://deepchat.dev/docs/directConnection/OpenAI#FunctionHandler.'
+    );
+  }
+}

--- a/component/src/services/azureOpenAI/utils/azureOpenAIAssistantUtils.ts
+++ b/component/src/services/azureOpenAI/utils/azureOpenAIAssistantUtils.ts
@@ -1,0 +1,186 @@
+import {OpenAIAssistantData, OpenAIAssistantContent, OpenAIAssistantMessagesResult} from '../../../types/openAIResult';
+import {MessageFileType, MessageFile} from '../../../types/messageFile';
+import {Messages} from '../../../views/chat/messages/messages';
+import {RequestUtils} from '../../../utils/HTTP/requestUtils';
+import {DirectServiceIO} from '../../utils/directServiceIO';
+import {AzureOpenAIUtils} from './azureOpenAIUtils';
+import {ServiceIO} from '../../serviceIO';
+import { AzureConfig } from '../../../types/azureOpenAI';
+
+type FileDetails = {fileId: string; path?: string; name?: string}[];
+
+export type UploadedFile = {id: string; name: string};
+
+export class AzureOpenAIAssistantUtils {
+  // triggered ONLY for file_search and code_interceptor
+  public static readonly FILES_WITH_TEXT_ERROR = 'content with type `text` must have `text` values';
+
+  public static readonly FUNCTION_TOOL_RESP_ERROR =
+    'Response must contain an array of strings for each individual function/tool_call, ' +
+    'see https://deepchat.dev/docs/directConnection/OpenAI/#assistant-functions.';
+
+  public static async storeFiles(serviceIO: ServiceIO, azureConfig: AzureConfig, messages: Messages, files: File[]) {
+    const headers = serviceIO.connectSettings.headers;
+    if (!headers) return;
+    serviceIO.url = `${azureConfig.endpoint}/openai/files?api-version=${azureConfig.version}`; // stores files
+    const previousContentType = headers[RequestUtils.CONTENT_TYPE];
+    delete headers[RequestUtils.CONTENT_TYPE];
+    const requests = files.map(async (file) => {
+      const formData = new FormData();
+      formData.append('purpose', 'assistants');
+      formData.append('file', file);
+      return new Promise<{id: string; filename: string}>((resolve) => {
+        resolve(AzureOpenAIUtils.directFetch(serviceIO, formData, 'POST', false)); // should perhaps use await but works without
+      });
+    });
+    try {
+      const uploadedFiles = (await Promise.all(requests)).map((result) => {
+        return {id: result.id, name: result.filename};
+      });
+      headers[RequestUtils.CONTENT_TYPE] = previousContentType;
+      return uploadedFiles as UploadedFile[];
+    } catch (err) {
+      headers[RequestUtils.CONTENT_TYPE] = previousContentType;
+      // error handled here as files not sent using HTTPRequest.request to not trigger the interceptors
+      RequestUtils.displayError(messages, err as object);
+      serviceIO.completionsHandlers.onFinish();
+      throw err;
+    }
+  }
+
+  private static getType(fileDetails: FileDetails, index: number): MessageFileType {
+    const {path} = fileDetails[index];
+    // images don't have a path
+    if (!path || path.endsWith('png')) return 'image';
+    return 'any';
+  }
+
+  private static async getFiles(serviceIO: ServiceIO, azureConfig: AzureConfig, fileDetails: FileDetails) {
+    const fileRequests = fileDetails.map(({fileId}) => {
+      // https://platform.openai.com/docs/api-reference/files/retrieve-contents
+      serviceIO.url = `${azureConfig.endpoint}/openai/files/${fileId}/content?api-version=${azureConfig.version}`;
+      return new Promise<Blob>((resolve) => {
+        resolve(AzureOpenAIUtils.directFetch(serviceIO, undefined, 'GET', false));
+      });
+    });
+    const blobs = await Promise.all(fileRequests);
+    const fileReaders = blobs.map((blob, index) => {
+      return new Promise<MessageFile>((resolve) => {
+        const reader = new FileReader();
+        reader.readAsDataURL(blob);
+        reader.onload = (event) => {
+          resolve({
+            src: (event.target as FileReader).result as string,
+            name: fileDetails[index].name,
+            type: AzureOpenAIAssistantUtils.getType(fileDetails, index),
+          });
+        };
+      });
+    });
+    return await Promise.all(fileReaders);
+  }
+
+  private static getFileName(path: string) {
+    const parts = path.split('/');
+    return parts[parts.length - 1];
+  }
+
+  // prettier-ignore
+  private static async getFilesAndNewText(io: ServiceIO, azureConfig: AzureConfig, fileDetails: FileDetails,
+      role?: string, content?: OpenAIAssistantContent) {
+    let files: MessageFile[] | undefined;
+    if (fileDetails.length > 0) {
+      files = await AzureOpenAIAssistantUtils.getFiles(io, azureConfig, fileDetails);
+      if (content?.text?.value) {
+        files.forEach((file, index) => {
+          if (!file.src) return;
+          const path = fileDetails[index].path;
+          if (content?.text?.value && path) {
+            content.text.value = content.text.value.replace(path, file.src);
+          }
+        });
+      }
+    }
+    // not displaying a separate file if annotated
+    return content?.text?.value ? {text: content.text.value, role} : {files, role};
+  }
+
+  // Noticed an issue where text contains a sandbox hyperlink to a csv, but no annotation provided
+  // To reproduce use the following text:
+  // give example data for a csv and create a suitable bar chart for it with a link
+  // Don't think it can be fixed and it is something on OpenAI side of things
+  // prettier-ignore
+  private static getFileDetails(lastMessage: OpenAIAssistantData, content?: OpenAIAssistantContent) {
+    const fileDetails: FileDetails = [];
+    if (content?.text?.value) {
+      lastMessage.content.forEach((content) => {
+        content.text?.annotations?.forEach((annotation) => {
+          if (annotation.text && annotation.text.startsWith('sandbox:') && annotation.file_path?.file_id) {
+            fileDetails.push({
+              path: annotation.text,
+              fileId: annotation.file_path.file_id,
+              name: AzureOpenAIAssistantUtils.getFileName(annotation.text),
+            });
+          }
+        });
+      });
+    }
+    if (content?.image_file) {
+      fileDetails.push({
+        fileId: content.image_file.file_id,
+      });
+    }
+    return fileDetails;
+  }
+
+  public static async getFilesAndText(io: ServiceIO, azureConfig: AzureConfig, message: OpenAIAssistantData, content?: OpenAIAssistantContent) {
+    const fileDetails = AzureOpenAIAssistantUtils.getFileDetails(message, content);
+    // gets files and replaces hyperlinks with base64 file encodings
+    return await AzureOpenAIAssistantUtils.getFilesAndNewText(io, azureConfig, fileDetails, message.role, content);
+  }
+
+  private static parseResult(result: OpenAIAssistantMessagesResult, isHistory: boolean) {
+    let messages = [];
+    if (isHistory) {
+      messages = result.data;
+    } else {
+      for (let i = 0; i < result.data.length; i += 1) {
+        const message = result.data[i];
+        if (message.role === 'assistant') {
+          messages.push(message);
+        } else {
+          break;
+        }
+      }
+    }
+    return messages.reverse();
+  }
+
+  // test this using this prompt and it should give 2 text mesages and a file:
+  // "give example data for a csv and create a suitable bar chart"
+  private static parseMessages(io: DirectServiceIO, azureConfig: AzureConfig, messages: OpenAIAssistantData[]) {
+    const parsedContent: Promise<{text?: string; files?: MessageFile[]}>[] = [];
+    messages.forEach(async (data) => {
+      data.content
+        .filter((content) => !!content.text || !!content.image_file)
+        .sort((content) => {
+          if (content.text) return -1;
+          if (content.image_file) return 1;
+          return 0;
+        })
+        .forEach(async (content) => {
+          parsedContent.push(AzureOpenAIAssistantUtils.getFilesAndText(io, azureConfig, data, content));
+        });
+    });
+    return Promise.all(parsedContent);
+  }
+
+  public static async processStreamMessages(io: DirectServiceIO, azureConfig: AzureConfig, content: OpenAIAssistantContent[]) {
+    return AzureOpenAIAssistantUtils.parseMessages(io, azureConfig, [{content, role: 'assistant'}]);
+  }
+
+  public static async processAPIMessages(io: DirectServiceIO, azureConfig: AzureConfig, result: OpenAIAssistantMessagesResult, isHistory: boolean) {
+    const messages = AzureOpenAIAssistantUtils.parseResult(result, isHistory);
+    return AzureOpenAIAssistantUtils.parseMessages(io, azureConfig, messages);
+  }
+}

--- a/component/src/services/azureOpenAI/utils/azureOpenAIUtils.ts
+++ b/component/src/services/azureOpenAI/utils/azureOpenAIUtils.ts
@@ -1,0 +1,48 @@
+import {KeyVerificationDetails} from '../../../types/keyVerificationDetails';
+import {ErrorMessages} from '../../../utils/errorMessages/errorMessages';
+import {OpenAIConverseResult} from '../../../types/openAIResult';
+import {RequestUtils} from '../../../utils/HTTP/requestUtils';
+import {ServiceIO} from '../../serviceIO';
+import { AzureConfig } from '../../../types/azureOpenAI';
+
+export class AzureOpenAIUtils {
+  public static buildHeaders(key: string) {
+    return {
+      "api-key": key,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  // prettier-ignore
+  private static handleVerificationResult(result: object, key: string,
+      onSuccess: (key: string) => void, onFail: (message: string) => void) {
+    const openAIResult = result as OpenAIConverseResult;
+    if (openAIResult.error) {
+      if (openAIResult.error.code === 'invalid_api_key') {
+        onFail(ErrorMessages.INVALID_KEY);
+      } else {
+        onFail(ErrorMessages.CONNECTION_FAILED);
+      }
+    } else {
+      onSuccess(key);
+    }
+  }
+
+  public static buildKeyVerificationDetails(azureConfig: AzureConfig): KeyVerificationDetails {
+    return {
+      url: `${azureConfig.endpoint}/openai/models?api-version=${azureConfig.version}`,
+      method: 'GET',
+      handleVerificationResult: AzureOpenAIUtils.handleVerificationResult,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public static async directFetch(serviceIO: ServiceIO, body: any, method: 'POST' | 'GET', stringify = true) {
+    serviceIO.connectSettings.method = method;
+    const result = await RequestUtils.fetch(serviceIO, serviceIO.connectSettings.headers, stringify, body).then((resp) =>
+      RequestUtils.processResponseByType(resp)
+    );
+    if (result.error) throw result.error.message;
+    return result;
+  }
+}

--- a/component/src/services/serviceIOFactory.ts
+++ b/component/src/services/serviceIOFactory.ts
@@ -29,6 +29,8 @@ import {WebModel} from '../webModel/webModel';
 import {MistralIO} from './mistral/mistralO';
 import {ServiceIO} from './serviceIO';
 import {DeepChat} from '../deepChat';
+import {AzureOpenAIAssistantIO} from './azureOpenAI/azureOpenAIAssistantIO';
+import {AzureOpenAIChatIO} from './azureOpenAI/azureOpenAIChatIO';
 
 // exercise caution when defining default returns for directConnection as their configs can be undefined
 export class ServiceIOFactory {
@@ -53,6 +55,12 @@ export class ServiceIOFactory {
           return new OpenAIAssistantIO(deepChat);
         }
         return new OpenAIChatIO(deepChat);
+      }
+      if (directConnection.azureOpenAI) {
+        if (directConnection.azureOpenAI.assistant) {
+          return new AzureOpenAIAssistantIO(deepChat);
+        }
+        return new AzureOpenAIChatIO(deepChat);
       }
       if (directConnection.assemblyAI) {
         return new AssemblyAIAudioIO(deepChat);

--- a/component/src/types/azureOpenAI.ts
+++ b/component/src/types/azureOpenAI.ts
@@ -1,0 +1,76 @@
+import {InterfacesUnion} from './utilityTypes';
+
+export type FunctionsDetails = {name: string; arguments: string}[];
+
+export type AssistantFunctionHandlerResponse = string[] | Promise<string>[];
+
+export type AssistantFunctionHandler = (functionsDetails: FunctionsDetails) => AssistantFunctionHandlerResponse;
+
+// https://platform.openai.com/docs/api-reference/assistants/createAssistant
+export interface AzureOpenAINewAssistant {
+  model?: string;
+  name?: string;
+  description?: string;
+  instructions?: string;
+  tools?: {
+    type: 'code_interpreter' | 'file_search' | 'function';
+    function?: {name: string; description?: string; parameters?: object};
+  }[];
+  tool_resources?: {
+    code_interpreter?: {
+      file_ids: string[];
+    };
+    file_search?: {
+      vector_store_ids?: string[];
+      vector_stores: {file_ids: string[]};
+    };
+  };
+}
+
+export type FileToolTypes = 'code_interpreter' | 'file_search' | 'images';
+
+// https://platform.openai.com/docs/api-reference/assistants
+export interface AzureOpenAIAssistant {
+  assistant_id?: string;
+  thread_id?: string;
+  load_thread_history?: boolean;
+  new_assistant?: AzureOpenAINewAssistant;
+  // if image is uploaded and this is undefined, it will default to images
+  // images can be used without a file tool type
+  files_tool_type?: FileToolTypes | ((fileNames: string[]) => FileToolTypes);
+  function_handler?: AssistantFunctionHandler;
+}
+
+export type ChatFunctionHandlerResponse = InterfacesUnion<{response: string}[] | {text: string}>;
+
+export type ChatFunctionHandler = (
+  functionsDetails: FunctionsDetails
+) => ChatFunctionHandlerResponse | Promise<ChatFunctionHandlerResponse>;
+
+export interface AzureOpenAIChatFunctions {
+  // parameters use the JSON Schema type
+  tools?: {type: 'function' | 'object'; function: {name: string; description?: string; parameters: object}}[];
+  tool_choice?: 'auto' | {type: 'function'; function: {name: string}};
+  function_handler?: ChatFunctionHandler;
+}
+
+// https://platform.openai.com/docs/api-reference/chat
+export type AzureOpenAIChat = {
+  system_prompt?: string;
+  model?: string;
+  max_tokens?: number; // number of tokens to reply - recommended to be set by the client
+  temperature?: number;
+  top_p?: number;
+} & AzureOpenAIChatFunctions;
+
+export type AzureConfig = {
+  endpoint: string;
+  version: string;
+  deploymentId: string;
+}
+
+export interface AzureOpenAI {
+  azureConfig: AzureConfig;
+  chat?: true | AzureOpenAIChat;
+  assistant?: true | AzureOpenAIAssistant;
+}

--- a/component/src/types/directConnection.ts
+++ b/component/src/types/directConnection.ts
@@ -6,9 +6,11 @@ import {APIKey} from './APIKey';
 import {Cohere} from './cohere';
 import {OpenAI} from './openAI';
 import {Azure} from './azure';
+import {AzureOpenAI} from './azureOpenAI';
 
 export interface DirectConnection {
   openAI?: OpenAI & APIKey;
+  azureOpenAI?: AzureOpenAI & APIKey;
   huggingFace?: HuggingFace & APIKey;
   mistral?: Mistral & APIKey;
   stabilityAI?: StabilityAI & APIKey;


### PR DESCRIPTION
This PR adds support for the Azure OpenAI Assistants API. Fixes #239 

```
    <deep-chat
      id="chat-element"
      directConnection='{
        "azureOpenAI": {
          "key": "YOUR_AZURE_KEY",
          "validateKeyProperty": true,
          "azureConfig": {
            "endpoint": "https://YOUR_RESOURCE_NAME.openai.azure.com",
            "version": "2024-05-01-preview"
          },
          "assistant": {
            "new_assistant": {
              "model": "gpt-4o",
              "name": "Test Azure Assistant",
              "description": "An assistant to test Azure integration into deep-chat",
              "instructions": "You are an assistant. Your instructions are to help test the integration of Azure with deep-chat",
              "tools": [
                { "type": "code_interpreter" },
                { "type": "file_search" }
              ]
            },
            "files_tool_type": "code_interpreter"
          }
        }
      }'
    ></deep-chat>
```
