### PR TITLE
Accessibility: Add semantics to textInput

### DIFF
--- a/component/src/views/chat/input/textInput/textInput.ts
+++ b/component/src/views/chat/input/textInput/textInput.ts
@@ -73,12 +73,15 @@ export class TextInputEl {
     const inputElement = document.createElement('div');
     inputElement.id = TextInputEl.TEXT_INPUT_ID;
     inputElement.classList.add('text-input-styling');
+    inputElement.role = 'textbox';
     if (Browser.IS_CHROMIUM) TextInputEl.preventAutomaticScrollUpOnNewLine(inputElement);
     if (typeof this._config.disabled === 'boolean' && this._config.disabled === true) {
       inputElement.contentEditable = 'false';
       inputElement.classList.add('text-input-disabled');
+      inputElement.setAttribute('aria-disabled', 'true');
     } else {
       inputElement.contentEditable = 'true';
+      inputElement.removeAttribute('aria-disabled');
       this.addEventListeners(inputElement);
     }
     Object.assign(inputElement.style, this._config.styles?.text);
@@ -127,6 +130,7 @@ export class TextInputEl {
 
   private setPlaceholderText(text: string) {
     this.inputElementRef.setAttribute('deep-chat-placeholder-text', text);
+    this.inputElementRef.setAttribute('aria-label', text);
   }
 
   public isTextInputEmpty() {


### PR DESCRIPTION
1. Adds role of textbox to textInput so screen-readers are told it is a text input
~2. Adds tabindex="0" to textInput so keyboard users can tab to it~
3. Adds aria-label to textInput so screen-reader users know what it does

All the above are because of limitations with being unable to add an `input` element and/or a `label`.

## note about `tabindex`
I opted not to add `tabindex=0` because I noticed in our implementation on eurostar.com that this seemed to stop the focus styling from working on the `#text-input-container` element. Plus there seems to be some work in place to allow the `div` to receive focus already so I felt it was not needed

https://github.com/OvidijusParsiunas/deep-chat/issues/285