### PR TITLE
feat: ollama support

### DIFF
--- a/component/src/services/ollama/ollamaOpenAIChatIO.ts
+++ b/component/src/services/ollama/ollamaOpenAIChatIO.ts
@@ -1,0 +1,48 @@
+import {OllamaOpenAIUtils} from './utils/ollamaOpenAIUtils';
+import {OpenAIChatIO} from '../openAI/openAIChatIO';
+import {DirectConnection} from '../../types/directConnection';
+import {OllamaOpenAI, URLDetails} from '../../types/ollama';
+import {OpenAIChat} from '../../types/openAI';
+import {DeepChat} from '../../deepChat';
+
+export class OllamaOpenAIChatIO extends OpenAIChatIO {
+  override permittedErrorPrefixes: string[] = [OllamaOpenAIUtils.URL_DETAILS_ERROR_MESSAGE];
+  isTextInputDisabled = false;
+
+  constructor(deepChat: DeepChat) {
+    const directConnectionCopy = JSON.parse(JSON.stringify(deepChat.directConnection)) as DirectConnection;
+    const urlDetails = directConnectionCopy.ollama?.openAI?.urlDetails || ({
+      endpoint: 'http://localhost:11434/v1',
+    } as URLDetails);
+    const config = directConnectionCopy.ollama?.openAI?.chat as OllamaOpenAI['chat'];
+
+    super(
+      deepChat,
+      OllamaOpenAIUtils.buildKeyVerificationDetails(urlDetails),
+      OllamaOpenAIUtils.buildHeaders,
+      {
+        key: 'ollama',
+        validateKeyProperty: false,
+      },
+      config,
+    );
+
+    if (typeof config === 'object') {
+      const {function_handler} = deepChat.directConnection?.ollama?.openAI?.chat as OpenAIChat;
+      if (function_handler) this._functionHandler = function_handler;
+    }
+    if (!OllamaOpenAIUtils.validateURLDetails(urlDetails)) {
+      this.isTextInputDisabled = true;
+      this.canSendMessage = () => false;
+      setTimeout(() => {
+        deepChat.addMessage({error: OllamaOpenAIUtils.URL_DETAILS_ERROR_MESSAGE});
+      });
+    } else {
+      this.url = OllamaOpenAIChatIO.buildURL(urlDetails);
+    }
+  }
+
+  private static buildURL(urlDetails: URLDetails) {
+    return `${urlDetails.endpoint}/chat/completions`;
+  }
+}

--- a/component/src/services/ollama/utils/ollamaOpenAIUtils.ts
+++ b/component/src/services/ollama/utils/ollamaOpenAIUtils.ts
@@ -1,0 +1,26 @@
+import {KeyVerificationDetails} from '../../../types/keyVerificationDetails';
+import {OpenAIUtils} from '../../openAI/utils/openAIUtils';
+import {URLDetails} from '../../../types/ollama';
+
+export class OllamaOpenAIUtils {
+  public static readonly URL_DETAILS_ERROR_MESSAGE =
+    'Please configure Ollama preferrably with OLLAMA_HOST and OLLAMA_ORIGINS set. [More Information](https://github.com/ollama/ollama/blob/main/docs/faq.md)';
+
+  public static buildHeaders(_apiKey: string) {
+    return {
+      'Content-Type': 'application/json',
+    };
+  }
+
+  public static buildKeyVerificationDetails(urlDetails: URLDetails): KeyVerificationDetails {
+    return {
+      url: `${urlDetails?.endpoint}/models`,
+      method: 'GET',
+      handleVerificationResult: OpenAIUtils.handleVerificationResult,
+    };
+  }
+
+  public static validateURLDetails(urlDetails: URLDetails) {
+    return urlDetails?.endpoint;
+  }
+}

--- a/component/src/services/openAI/openAIChatIO.ts
+++ b/component/src/services/openAI/openAIChatIO.ts
@@ -41,7 +41,7 @@ export class OpenAIChatIO extends DirectServiceIO {
     const config = configArg || directConnectionCopy.openAI?.chat; // can be undefined as this is the default service
     if (typeof config === 'object') {
       if (config.system_prompt) this._systemMessage = OpenAIChatIO.generateSystemMessage(config.system_prompt);
-      const {function_handler} = deepChat.directConnection?.openAI?.chat as OpenAIChat;
+      const {function_handler} = config as OpenAIChat;
       if (function_handler) this._functionHandler = function_handler;
       this.cleanConfig(config);
       Object.assign(this.rawBody, config);

--- a/component/src/services/serviceIOFactory.ts
+++ b/component/src/services/serviceIOFactory.ts
@@ -28,6 +28,7 @@ import {OpenAIImagesIO} from './openAI/openAIImagesIO';
 import {BaseServiceIO} from './utils/baseServiceIO';
 import {OpenAIChatIO} from './openAI/openAIChatIO';
 import {CohereChatIO} from './cohere/cohereChatIO';
+import {OllamaOpenAIChatIO } from './ollama/ollamaOpenAIChatIO';
 import {WebModel} from '../webModel/webModel';
 import {MistralIO} from './mistral/mistralO';
 import {ServiceIO} from './serviceIO';
@@ -135,6 +136,13 @@ export class ServiceIOFactory {
       }
       if (directConnection.mistral) {
         return new MistralIO(deepChat);
+      }
+      if (directConnection.ollama) {
+        if (directConnection.ollama.openAI) {
+          if (directConnection.ollama.openAI.chat) {
+            return new OllamaOpenAIChatIO(deepChat);
+          }
+        }
       }
     }
     // if connect, make sure it is not a demo stream

--- a/component/src/types/directConnection.ts
+++ b/component/src/types/directConnection.ts
@@ -6,6 +6,7 @@ import {APIKey} from './APIKey';
 import {Cohere} from './cohere';
 import {OpenAI} from './openAI';
 import {Azure} from './azure';
+import {Ollama} from './ollama';
 
 export interface DirectConnection {
   openAI?: OpenAI & APIKey;
@@ -15,4 +16,5 @@ export interface DirectConnection {
   cohere?: Cohere & APIKey;
   azure?: Azure & APIKey;
   assemblyAI?: AssemblyAI & APIKey;
+  ollama?: Ollama;
 }

--- a/component/src/types/ollama.ts
+++ b/component/src/types/ollama.ts
@@ -1,0 +1,14 @@
+import {OpenAIChat} from './openAI';
+
+export type URLDetails = {
+  endpoint: string;
+};
+
+export interface OllamaOpenAI {
+  urlDetails?: URLDetails;
+  chat?: true | OpenAIChat;
+}
+
+export interface Ollama {
+  openAI?: OllamaOpenAI;
+}


### PR DESCRIPTION
For #262.

Made a few hacks:

- `openAIChatIO.ts`: `deepChat.directConnection?.openAI?.chat` could be unset when using a non-OpenAI but OpenAI compatible class.
- `OllamaOpenAIChatIO`:
  - overriding `key` to set a placeholder one as refactoring up till `HTTPRequest.verifyKey` is way too troublesome.
  - as well as setting `validateKeyProperty` to `false`