### PR TITLE
Add onMessage events for OpenAI realtime

### DIFF
--- a/component/src/services/openAI/realtime/openAIRealtimeIO.ts
+++ b/component/src/services/openAI/realtime/openAIRealtimeIO.ts
@@ -393,6 +393,22 @@ export class OpenAIRealtimeIO extends DirectServiceIO {
         this.stopOnError(response.message);
       } else if (response.type === 'response.audio_transcript.delta') {
         // console.log(response.delta);
+      } else if (response.type === 'response.audio_transcript.done') {
+        // AI message transcription is complete
+        if (response.transcript) {
+          this._events?.onMessage?.({
+            message: {role: 'ai', text: response.transcript},
+            isHistory: false
+          });
+        }
+      } else if (response.type === 'conversation.item.input_audio_transcription.completed') {
+        // User message transcription is complete
+        if (response.transcript) {
+          this._events?.onMessage?.({
+            message: {role: 'user', text: response.transcript},
+            isHistory: false
+          });
+        }
       }
     });
 

--- a/component/src/types/speechToSpeechEvents.ts
+++ b/component/src/types/speechToSpeechEvents.ts
@@ -1,4 +1,7 @@
+import {OnMessage} from './messages';
+
 export interface SpeechToSpeechEvents {
   started?: () => void;
   stopped?: () => void;
+  onMessage?: OnMessage;
 }

--- a/website/docs/docs/directConnection/OpenAI/OpenAIRealtime.mdx
+++ b/website/docs/docs/directConnection/OpenAI/OpenAIRealtime.mdx
@@ -672,11 +672,12 @@ chatElementRef.openAI.realtime.methods.sendMessage('Are you a real human?', 'use
 
 ### `SpeechToSpeechEvents` {#SpeechToSpeechEvents}
 
-- Functions: \{ `started?:` () => `void`, `stopped?:` () => `void` \}
+- Functions: \{ `started?:` () => `void`, `stopped?:` () => `void`, [`onMessage?: OnMessage`](/docs/events#onMessage) \}
 - Events: `sts-session-started` | `sts-session-stopped`
 
 `started`/`sts-session-started` is triggered when the conversion has started. <br />
 `stopped`/`sts-session-stopped` is triggered when the conversion has stopped. <br />
+`onMessage` is triggered when voice messages are transcribed to text (both user and AI messages). This uses the same [`OnMessage`](/docs/events#onMessage) interface as regular chat messages. For user messages, you must enable `input_audio_transcription` in the [`config`](#OpenAIRealtimeConfig). AI message transcription is enabled by default. <br />
 
 {' '}
 <ContainersKeyToggle>
@@ -712,6 +713,10 @@ chatElementRef.openAI.realtime.methods.sendMessage('Are you a real human?', 'use
 chatElementRef.directConnection.openAI.realtime.events = {
   started: () => console.log('Session started'),
   stopped: () => console.log('Session stopped'),
+  onMessage: (body) => {
+    const {message, isHistory} = body;
+    console.log(`${message.role} said: ${message.text}`);
+  },
 };
 ```
 
@@ -728,6 +733,126 @@ chatElementRef.addEventListener('sts-session-started', () => {
 chatElementRef.addEventListener('sts-session-stopped', () => {
   console.log('Session stopped');
 });
+```
+
+</TabItem>
+</Tabs>
+
+<LineBreak></LineBreak>
+
+#### Message Transcription Example
+
+The following example shows how to capture transcribed messages from voice conversations:
+
+<ContainersKeyToggle>
+  <ComponentContainer>
+    <DeepChatBrowser
+      style={{borderRadius: '8px'}}
+      directConnection={{
+        openAI: {
+          key: 'placeholder key',
+          realtime: {
+            config: {
+              input_audio_transcription: { model: "whisper-1" }
+            },
+            events: {
+              onMessage: (body) => {
+                console.log(`${body.message.role} said: ${body.message.text}`);
+              }
+            }
+          },
+        },
+      }}
+    ></DeepChatBrowser>
+  </ComponentContainer>
+  <ComponentContainer>
+    <DeepChatBrowser
+      style={{borderRadius: '8px'}}
+      directConnection={{
+        openAI: {
+          realtime: {
+            config: {
+              input_audio_transcription: { model: "whisper-1" }
+            },
+            events: {
+              onMessage: (body) => {
+                console.log(`${body.message.role} said: ${body.message.text}`);
+              }
+            }
+          },
+        },
+      }}
+    ></DeepChatBrowser>
+  </ComponentContainer>
+</ContainersKeyToggle>
+
+<Tabs>
+<TabItem value="js" label="Sample code">
+
+```html
+<deep-chat
+  directConnection='{
+    "openAI": {
+      "key": "placeholder key",
+      "realtime": {
+        "config": {
+          "input_audio_transcription": {"model": "whisper-1"}
+        },
+        "events": {
+          "onMessage": "chatElementRef.handleMessage"
+        }
+      }
+    }
+  }'
+></deep-chat>
+
+<script>
+  // Define handler function
+  const chatElementRef = document.querySelector('deep-chat');
+  chatElementRef.handleMessage = (body) => {
+    const {message, isHistory} = body;
+    console.log(`${message.role} said: ${message.text}`);
+    // message.role will be 'user' or 'ai'
+    // message.text contains the transcribed speech
+  };
+</script>
+```
+
+</TabItem>
+<TabItem value="py" label="Full code">
+
+```html
+<!-- This example is for Vanilla JS and should be tailored to your framework (see Examples) -->
+
+<deep-chat
+  directConnection='{
+    "openAI": {
+      "key": "placeholder key",
+      "realtime": {
+        "config": {
+          "input_audio_transcription": {"model": "whisper-1"}
+        }
+      }
+    }
+  }'
+  style="border-radius: 8px"
+></deep-chat>
+
+<script>
+  // Retrieve element reference
+  const chatElementRef = document.querySelector('deep-chat');
+
+  // Set up message handler
+  chatElementRef.directConnection.openAI.realtime.events = {
+    onMessage: (body) => {
+      const {message, isHistory} = body;
+      console.log(`${message.role} said: ${message.text}`);
+
+      // You can also access other MessageContent properties:
+      // message.files, message.html, message.custom, etc.
+    }
+  };
+</script>
 ```
 
 </TabItem>

--- a/website/docs/docs/events.mdx
+++ b/website/docs/docs/events.mdx
@@ -14,7 +14,8 @@ Events can be observed in two ways, either by assigning a function to a property
 
 Triggered when a message is sent from the user and recieved from the target service. <br />
 `message` encompasses all of the message contents. <br />
-`isHistory` is used to determine whether if the message is from the prepopulated [`history`](/docs/messages#history) property.
+`isHistory` is used to determine whether if the message is from the prepopulated [`history`](/docs/messages#history) property. <br />
+This event is also available for [OpenAI Realtime](/docs/directConnection/OpenAI/OpenAIRealtime#SpeechToSpeechEvents) voice conversations when transcription is enabled.
 
 #### Example
 


### PR DESCRIPTION
  ## Summary
  - Add `onMessage` event support for OpenAI Realtime API to capture transcribed voice messages
  - Uses the same `OnMessage` interface as regular chat messages for API consistency
  - Supports both user and AI message transcriptions

  ## Changes Made

  ### Core Implementation
  - **Extended `SpeechToSpeechEvents` interface** to include `onMessage?: OnMessage`
  - **Added event handlers** for `response.audio_transcript.done` (AI messages) and
  `conversation.item.input_audio_transcription.completed` (user messages)
  - **Consistent API design** using the standard `MessageContent` structure with `role` property

  ### Documentation Updates
  - **Updated OpenAI Realtime docs** with comprehensive examples showing transcription setup
  - **Added cross-references** in main events documentation
  - **Provided clear usage examples** for both simple and advanced use cases

  ## Usage Example

  ```typescript
  deepChat.directConnection = {
    openAI: {
      realtime: {
        config: {
          input_audio_transcription: { model: "whisper-1" } // Enable user transcription
        },
        events: {
          onMessage: (body) => {
            console.log(`${body.message.role} said: ${body.message.text}`);
            // body.message.role will be 'user' or 'ai'
            // Uses same interface as regular chat onMessage
          }
        }
      }
    }
  };