### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/component/src/services/liteLLM/liteLLMIO.ts
+++ b/component/src/services/liteLLM/liteLLMIO.ts
@@ -30,6 +30,7 @@ export class LiteLLMIO extends DirectServiceIO {
     if (typeof config === OBJECT) {
       if ((config as LiteLLM & {url?: string}).url) {
         this.url = (config as LiteLLM & {url?: string}).url!;
+        delete (config as LiteLLM & {url?: string}).url;
       }
       this.completeConfig(config);
     }

--- a/component/src/services/liteLLM/liteLLMIO.ts
+++ b/component/src/services/liteLLM/liteLLMIO.ts
@@ -1,0 +1,76 @@
+import {AUTHENTICATION_ERROR_PREFIX, INVALID_REQUEST_ERROR_PREFIX, OBJECT} from '../utils/serviceConstants';
+import {LITELLM_BUILD_HEADERS, LITELLM_BUILD_KEY_VERIFICATION_DETAILS} from './utils/liteLLMUtils';
+import {LiteLLMRequestBody, LiteLLMMessage} from '../../types/liteLLMInternal';
+import {DEEP_COPY, ERROR, ROLE, TEXT} from '../../utils/consts/messageConstants';
+import {DirectConnection} from '../../types/directConnection';
+import {MessageContentI} from '../../types/messagesInternal';
+import {Messages} from '../../views/chat/messages/messages';
+import {Response as ResponseI} from '../../types/response';
+import {LiteLLMResult} from '../../types/liteLLMResult';
+import {DirectServiceIO} from '../utils/directServiceIO';
+import {LiteLLM} from '../../types/liteLLM';
+import {APIKey} from '../../types/APIKey';
+import {DeepChat} from '../../deepChat';
+
+// https://docs.litellm.ai/docs/
+export class LiteLLMIO extends DirectServiceIO {
+  override insertKeyPlaceholderText = this.genereteAPIKeyName('LiteLLM');
+  override keyHelpUrl = 'https://docs.litellm.ai/docs/simple_proxy#quick-start';
+  url = 'http://localhost:4000/v1/chat/completions';
+  permittedErrorPrefixes = [INVALID_REQUEST_ERROR_PREFIX, AUTHENTICATION_ERROR_PREFIX];
+
+  constructor(deepChat: DeepChat) {
+    const directConnectionCopy = DEEP_COPY(deepChat.directConnection) as DirectConnection;
+    const config = directConnectionCopy.liteLLM as LiteLLM & APIKey;
+    const configUrl =
+      typeof config === OBJECT && (config as LiteLLM & {url?: string}).url
+        ? (config as LiteLLM & {url?: string}).url!
+        : 'http://localhost:4000/v1/chat/completions';
+    super(deepChat, LITELLM_BUILD_KEY_VERIFICATION_DETAILS(configUrl), LITELLM_BUILD_HEADERS, config);
+    if (typeof config === OBJECT) {
+      if ((config as LiteLLM & {url?: string}).url) {
+        this.url = (config as LiteLLM & {url?: string}).url!;
+      }
+      this.completeConfig(config);
+    }
+    this.maxMessages ??= -1;
+    this.rawBody.model ??= 'gpt-4o-mini';
+    this.rawBody.temperature ??= 1;
+    this.rawBody.max_tokens ??= 4096;
+  }
+
+  private preprocessBody(body: LiteLLMRequestBody, pMessages: MessageContentI[]) {
+    const bodyCopy = DEEP_COPY(body) as LiteLLMRequestBody;
+    const processedMessages = this.processMessages(pMessages).map((message) => {
+      return {
+        content: message[TEXT] || '',
+        [ROLE]: DirectServiceIO.getRoleViaUser(message[ROLE]),
+      } as LiteLLMMessage;
+    });
+    this.addSystemMessage(processedMessages);
+    bodyCopy.messages = processedMessages;
+    return bodyCopy;
+  }
+
+  override async callServiceAPI(messages: Messages, pMessages: MessageContentI[]) {
+    this.callDirectServiceServiceAPI(messages, pMessages, this.preprocessBody.bind(this), {});
+  }
+
+  override async extractResultData(result: LiteLLMResult): Promise<ResponseI> {
+    if (result[ERROR]) throw result[ERROR].message;
+
+    if (result.choices && result.choices.length > 0) {
+      const choice = result.choices[0];
+
+      if (choice.delta && choice.delta.content) {
+        return {[TEXT]: choice.delta.content};
+      }
+
+      if (choice.message && choice.message.content) {
+        return {[TEXT]: choice.message.content};
+      }
+    }
+
+    return {[TEXT]: ''};
+  }
+}

--- a/component/src/services/liteLLM/utils/liteLLMUtils.ts
+++ b/component/src/services/liteLLM/utils/liteLLMUtils.ts
@@ -1,0 +1,27 @@
+import {BUILD_KEY_VERIFICATION_DETAILS} from '../../utils/directServiceUtils';
+import {KeyVerificationDetails} from '../../../types/keyVerificationDetails';
+import {
+  CONTENT_TYPE_H_KEY,
+  APPLICATION_JSON,
+  AUTHORIZATION_H,
+  BEARER_PREFIX,
+} from '../../utils/serviceConstants';
+
+export const LITELLM_BUILD_HEADERS = (key: string) => {
+  return {
+    [AUTHORIZATION_H]: `${BEARER_PREFIX}${key}`,
+    [CONTENT_TYPE_H_KEY]: APPLICATION_JSON,
+  };
+};
+
+export const LITELLM_BUILD_KEY_VERIFICATION_DETAILS = (url: string): KeyVerificationDetails => {
+  const modelsUrl = url.replace(/\/chat\/completions\/?$/, '/models');
+  return BUILD_KEY_VERIFICATION_DETAILS(modelsUrl, 'GET', (result, key, onSuccess, onFail) => {
+    const resultObj = result as {error?: {message: string}; data?: unknown[]};
+    if (resultObj.error) {
+      onFail(resultObj.error.message);
+    } else {
+      onSuccess(key);
+    }
+  });
+};

--- a/component/src/services/serviceIOFactory.ts
+++ b/component/src/services/serviceIOFactory.ts
@@ -52,6 +52,7 @@ import {QwenIO} from './qwen/qwenIO';
 import {KimiIO} from './kimi/kimiIO';
 import {DeepChat} from '../deepChat';
 import {XChatIO} from './x/xChatIO';
+import {LiteLLMIO} from './liteLLM/liteLLMIO';
 import {DifyIO} from './dify/difyIO';
 
 // exercise caution when defining default returns for directConnection as their configs can be undefined
@@ -216,6 +217,9 @@ export class ServiceIOFactory {
       }
       if (directConnection.dify) {
         return new DifyIO(deepChat);
+      }
+      if (directConnection.liteLLM) {
+        return new LiteLLMIO(deepChat);
       }
     }
     if (connect && Object.keys(connect).length > 0 && !demo) {

--- a/component/src/types/directConnection.ts
+++ b/component/src/types/directConnection.ts
@@ -20,7 +20,8 @@ import {Groq} from './groq';
 import {Kimi} from './kimi';
 import {Qwen} from './qwen';
 import {X} from './x';
-import { Dify } from './dify';
+import {LiteLLM} from './liteLLM';
+import {Dify} from './dify';
 
 export interface DirectConnection {
   openAI?: OpenAI & APIKey;
@@ -45,4 +46,5 @@ export interface DirectConnection {
   ollama?: Ollama;
   openWebUI?: OpenWebUI & APIKey;
   dify?: Dify & APIKey;
+  liteLLM?: LiteLLM & APIKey;
 }

--- a/component/src/types/liteLLM.ts
+++ b/component/src/types/liteLLM.ts
@@ -1,0 +1,13 @@
+export interface LiteLLMChat {
+  model?: string;
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  stop?: string | string[];
+  system_prompt?: string;
+  url?: string;
+}
+
+export type LiteLLM = true | LiteLLMChat;

--- a/component/src/types/liteLLMInternal.ts
+++ b/component/src/types/liteLLMInternal.ts
@@ -1,0 +1,16 @@
+export type LiteLLMMessage = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+export type LiteLLMRequestBody = {
+  model: string;
+  messages: LiteLLMMessage[];
+  stream?: boolean;
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  stop?: string | string[];
+};

--- a/component/src/types/liteLLMResult.ts
+++ b/component/src/types/liteLLMResult.ts
@@ -1,0 +1,28 @@
+export type LiteLLMResult = {
+  id: string;
+  object: 'chat.completion' | 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message?: {
+      role: 'assistant';
+      content: string;
+    };
+    delta?: {
+      role?: 'assistant';
+      content?: string;
+    };
+    finish_reason?: string;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+  error?: {
+    message: string;
+    type: string;
+    code?: string;
+  };
+};


### PR DESCRIPTION


Closes #506

## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a new direct connection provider, enabling users to route chat through 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Ollama, etc.) via a single LiteLLM proxy.
- Follows the existing provider pattern (modeled after DeepSeek provider).

## Motivation
LiteLLM acts as a unified AI gateway. Instead of configuring individual provider connections, users can point deep-chat at a single LiteLLM proxy that handles provider routing, load balancing, and cost tracking across 100+ providers. This is especially useful for users who self-host their LLM infrastructure or need to use providers not yet directly supported by deep-chat (e.g., AWS Bedrock, Vertex AI).

## Changes

- `component/src/services/liteLLM/liteLLMIO.ts` - new `LiteLLMIO` extending `DirectServiceIO`, handles chat completions via LiteLLM proxy with configurable `url` for custom proxy endpoints
- `component/src/services/liteLLM/utils/liteLLMUtils.ts` - header builder and key verification via proxy's `/v1/models` endpoint
- `component/src/types/liteLLM.ts` - `LiteLLM` config type with `url`, `model`, `temperature`, `max_tokens` etc.
- `component/src/types/liteLLMResult.ts` - OpenAI-compatible response type (streaming + non-streaming)
- `component/src/types/liteLLMInternal.ts` - request body and message types
- `component/src/types/directConnection.ts` - added `liteLLM` to `DirectConnection` interface
- `component/src/services/serviceIOFactory.ts` - registered `LiteLLMIO` in factory

## Tests

**1. TypeScript type check clean:**

    $ npx tsc --noEmit
    (no errors)

**2. Build passes:**

    $ npm run build
    dist/deepChat.js  511.30 kB | gzip: 126.95 kB
    built in 1.50s

## Risk / Compatibility
- Additive only. No existing providers or types modified (except adding to `DirectConnection` interface and factory).
- Default proxy URL is `http://localhost:4000/v1/chat/completions` (standard LiteLLM proxy port). Users configure via the `url` property.
- Uses OpenAI-compatible request/response format, which is what the LiteLLM proxy serves.

## Example usage

    <deep-chat
      directConnection='{
        "liteLLM": {
          "key": "sk-your-litellm-key",
          "url": "http://localhost:4000/v1/chat/completions",
          "model": "anthropic/claude-3-5-sonnet",
          "temperature": 0.7,
          "max_tokens": 4096,
          "system_prompt": "You are a helpful assistant."
        }
      }'
    ></deep-chat>

Or with just the defaults (connects to local proxy):

    <deep-chat
      directConnection='{"liteLLM": {"key": "sk-1234"}}'
    ></deep-chat>
