### PR TITLE
Add Requesty as an OpenAI-compatible direct-connection provider

### DIFF
--- a/component/src/services/requesty/requestyIO.ts
+++ b/component/src/services/requesty/requestyIO.ts
@@ -1,0 +1,169 @@
+import {AUDIO, DEEP_COPY, ERROR, FILES, IMAGES, ROLE, SRC, TEXT, TYPE} from '../../utils/consts/messageConstants';
+import {REQUESTY_BUILD_HEADERS, REQUESTY_BUILD_KEY_VERIFICATION_DETAILS} from './utils/requestyUtils';
+import {RequestyAPIResult, RequestyStreamEvent} from '../../types/requestyResult';
+import {Requesty, RequestyChat} from '../../types/requesty';
+import {DirectConnection} from '../../types/directConnection';
+import {MessageContentI} from '../../types/messagesInternal';
+import {Messages} from '../../views/chat/messages/messages';
+import {Response as ResponseI} from '../../types/response';
+import {DirectServiceIO} from '../utils/directServiceIO';
+import {MessageFile} from '../../types/messageFile';
+import {APIKey} from '../../types/APIKey';
+import {DeepChat} from '../../deepChat';
+import {
+  RequestyRequestBody,
+  RequestyToolCall,
+  RequestyMessage,
+  RequestyContent,
+} from '../../types/requestyInternal';
+import {
+  INVALID_REQUEST_ERROR_PREFIX,
+  AUTHENTICATION_ERROR_PREFIX,
+  INPUT_AUDIO,
+  IMAGE_URL,
+  OBJECT,
+  SYSTEM,
+} from '../utils/serviceConstants';
+
+// https://docs.requesty.ai/
+export class RequestyIO extends DirectServiceIO {
+  override insertKeyPlaceholderText = this.genereteAPIKeyName('Requesty');
+  override keyHelpUrl = 'https://app.requesty.ai/api-keys';
+  url = 'https://router.requesty.ai/v1/chat/completions';
+  permittedErrorPrefixes = [INVALID_REQUEST_ERROR_PREFIX, AUTHENTICATION_ERROR_PREFIX];
+  readonly _streamToolCalls?: RequestyToolCall[];
+
+  constructor(deepChat: DeepChat) {
+    const directConnectionCopy = DEEP_COPY(deepChat.directConnection) as DirectConnection;
+    const config = directConnectionCopy.requesty as Requesty & APIKey;
+    super(deepChat, REQUESTY_BUILD_KEY_VERIFICATION_DETAILS(), REQUESTY_BUILD_HEADERS, config);
+    if (typeof config === OBJECT) {
+      this.completeConfig(config, (deepChat.directConnection?.requesty as RequestyChat)?.function_handler);
+    }
+    this.maxMessages ??= -1;
+    this.rawBody.model ??= 'openai/gpt-4o';
+    this.rawBody.max_tokens ??= 1000;
+  }
+
+  private static getAudioContent(files: MessageFile[]): RequestyContent[] {
+    return files
+      .filter((file) => file[TYPE] === AUDIO)
+      .map((file) => {
+        const base64Data = file[SRC]?.split(',')[1];
+        const format = file[SRC]?.match(/data:audio\/([^;]+)/)?.[1] as 'wav' | 'mp3';
+        return {
+          [TYPE]: INPUT_AUDIO as 'input_audio',
+          [INPUT_AUDIO]: {
+            data: base64Data || '',
+            format: format === 'wav' || format === 'mp3' ? format : 'mp3',
+          },
+        };
+      })
+      .filter((content) => content[INPUT_AUDIO].data.length > 0);
+  }
+
+  private static getContent(message: MessageContentI): string | RequestyContent[] {
+    if (message[FILES] && message[FILES].length > 0) {
+      const content: RequestyContent[] = [
+        ...RequestyIO.getImageContent(message[FILES]),
+        ...RequestyIO.getAudioContent(message[FILES]),
+      ];
+      if (message[TEXT] && message[TEXT].trim().length > 0) {
+        content.unshift({[TYPE]: TEXT, [TEXT]: message[TEXT]});
+      }
+      return content.length > 0 ? content : message[TEXT] || '';
+    }
+    return message[TEXT] || '';
+  }
+
+  private preprocessBody(body: RequestyRequestBody, pMessages: MessageContentI[]) {
+    const bodyCopy = DEEP_COPY(body) as RequestyRequestBody;
+    const processedMessages = this.processMessages(pMessages).map((message) => {
+      return {
+        content: RequestyIO.getContent(message),
+        [ROLE]: DirectServiceIO.getRoleViaUser(message[ROLE]),
+      } as RequestyMessage;
+    });
+
+    const messages: RequestyMessage[] = [];
+    if (this.systemMessage) messages.push({[ROLE]: SYSTEM, content: this.systemMessage});
+    messages.push(...processedMessages);
+
+    bodyCopy.messages = messages;
+    return bodyCopy;
+  }
+
+  override async callServiceAPI(messages: Messages, pMessages: MessageContentI[]) {
+    this.messages ??= messages;
+    this.callDirectServiceServiceAPI(messages, pMessages, this.preprocessBody.bind(this), {});
+  }
+
+  override async extractResultData(result: RequestyAPIResult, prevBody?: Requesty): Promise<ResponseI> {
+    if (result[ERROR]) throw result[ERROR].message;
+
+    // Handle streaming events
+    if (result.object === 'chat.completion.chunk') {
+      const choice = result.choices?.[0];
+      if (choice?.delta) {
+        return this.extractStreamResult(choice, prevBody);
+      }
+
+      // Handle streaming response with images
+      if (result.message?.[IMAGES]) {
+        const files = result.message[IMAGES].map((image) => ({
+          [SRC]: image[IMAGE_URL].url,
+        }));
+
+        return {
+          [TEXT]: result.message.content || '',
+          [FILES]: files,
+        };
+      }
+
+      return {[TEXT]: ''};
+    }
+
+    // Handle non-streaming response
+    if (result.object === 'chat.completion') {
+      const choice = result.choices?.[0];
+      if (choice?.message) {
+        if (choice.message.tool_calls) {
+          return this.handleToolsGeneric(
+            {tool_calls: choice.message.tool_calls},
+            this.functionHandler,
+            this.messages,
+            prevBody
+          );
+        }
+
+        const files =
+          choice.message[IMAGES]?.map((image) => ({
+            [SRC]: image[IMAGE_URL].url,
+          })) || [];
+
+        return {
+          [TEXT]: choice.message.content || '',
+          files,
+        };
+      }
+    }
+
+    return {[TEXT]: ''};
+  }
+
+  private async extractStreamResult(choice: RequestyStreamEvent['choices'][0], prevBody?: Requesty) {
+    const {delta} = choice;
+    // Handle streaming response with images
+    if (delta?.[IMAGES]) {
+      const files = delta[IMAGES].map((image) => ({
+        [SRC]: image[IMAGE_URL].url,
+      }));
+
+      return {
+        [TEXT]: delta.content || '',
+        [FILES]: files,
+      };
+    }
+    return this.extractStreamResultWToolsGeneric(this, choice, this.functionHandler, prevBody);
+  }
+}

--- a/component/src/services/requesty/utils/requestyUtils.ts
+++ b/component/src/services/requesty/utils/requestyUtils.ts
@@ -1,0 +1,50 @@
+import {INVALID_KEY, CONNECTION_FAILED} from '../../../utils/errorMessages/errorMessages';
+import {BUILD_KEY_VERIFICATION_DETAILS} from '../../utils/directServiceUtils';
+import {KeyVerificationDetails} from '../../../types/keyVerificationDetails';
+import {ERROR, TYPE} from '../../../utils/consts/messageConstants';
+import {
+  AUTHENTICATION_ERROR_PREFIX,
+  CONTENT_TYPE_H_KEY,
+  APPLICATION_JSON,
+  AUTHORIZATION_H,
+  BEARER_PREFIX,
+  GET,
+} from '../../utils/serviceConstants';
+
+type RequestyErrorResponse = {
+  error?: {
+    message: string;
+    type: string;
+    code?: string;
+  };
+};
+
+export const REQUESTY_BUILD_HEADERS = (key: string) => {
+  return {
+    [AUTHORIZATION_H]: `${BEARER_PREFIX}${key}`,
+    [CONTENT_TYPE_H_KEY]: APPLICATION_JSON,
+  };
+};
+
+const handleVerificationResult = (
+  result: object,
+  key: string,
+  onSuccess: (key: string) => void,
+  onFail: (message: string) => void
+) => {
+  const requestyResult = result as RequestyErrorResponse;
+  if (requestyResult[ERROR]) {
+    if (requestyResult[ERROR][TYPE] === AUTHENTICATION_ERROR_PREFIX) {
+      onFail(INVALID_KEY);
+    } else {
+      onFail(CONNECTION_FAILED);
+    }
+  } else {
+    onSuccess(key);
+  }
+};
+
+export const REQUESTY_BUILD_KEY_VERIFICATION_DETAILS = (): KeyVerificationDetails => {
+  // Will return a 400 error, but it is fine as long as it is not 401
+  return BUILD_KEY_VERIFICATION_DETAILS('https://router.requesty.ai/v1/models', GET, handleVerificationResult);
+};

--- a/component/src/services/serviceIOFactory.ts
+++ b/component/src/services/serviceIOFactory.ts
@@ -33,6 +33,7 @@ import {TogetherChatIO} from './together/togetherChatIO';
 import {IMAGES} from '../utils/consts/messageConstants';
 import {OpenAIImagesIO} from './openAI/openAIImagesIO';
 import {OpenRouterIO} from './openRouter/openRouterIO';
+import {RequestyIO} from './requesty/requestyIO';
 import {PerplexityIO} from './perplexity/perplexityIO';
 import {BaseServiceIO} from './utils/baseServiceIO';
 import {OpenWebUIIO} from './openWebUI/openWebUIIO';
@@ -169,6 +170,9 @@ export class ServiceIOFactory {
       }
       if (directConnection.openRouter) {
         return new OpenRouterIO(deepChat);
+      }
+      if (directConnection.requesty) {
+        return new RequestyIO(deepChat);
       }
       if (directConnection.kimi) {
         return new KimiIO(deepChat);

--- a/component/src/types/directConnection.ts
+++ b/component/src/types/directConnection.ts
@@ -2,6 +2,7 @@ import {HuggingFace} from './huggingFace';
 import {StabilityAI} from './stabilityAI';
 import {AssemblyAI} from './assemblyAI';
 import {OpenRouter} from './openRouter';
+import {Requesty} from './requesty';
 import {Perplexity} from './perplexity';
 import {OpenWebUI} from './openWebUI';
 import {DeepSeek} from './deepSeek';
@@ -37,6 +38,7 @@ export interface DirectConnection {
   kimi?: Kimi & APIKey;
   miniMax?: MiniMax & APIKey;
   openRouter?: OpenRouter & APIKey;
+  requesty?: Requesty & APIKey;
   x?: X & APIKey;
   qwen?: Qwen & APIKey;
   together?: Together & APIKey;

--- a/component/src/types/requesty.ts
+++ b/component/src/types/requesty.ts
@@ -1,0 +1,47 @@
+import {ChatFunctionHandler} from './openAI';
+
+export interface RequestyTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: object;
+  };
+}
+
+export type RequestyToolChoice = 'auto' | 'none' | 'required' | {type: 'function'; function: {name: string}};
+
+export interface RequestyResponseFormat {
+  type: 'text' | 'json_object' | 'json_schema';
+  json_schema?: {
+    name: string;
+    description?: string;
+    schema: object;
+    strict?: boolean;
+  };
+}
+
+export interface RequestyReasoning {
+  effort?: 'low' | 'medium' | 'high';
+  max_tokens?: number;
+  exclude?: boolean;
+  enabled?: boolean;
+}
+
+// https://docs.requesty.ai/
+export interface RequestyChat {
+  model?: string;
+  models?: string[];
+  max_tokens?: number;
+  max_completion_tokens?: number;
+  stop?: string | string[];
+  system_prompt?: string;
+  tools?: RequestyTool[];
+  tool_choice?: RequestyToolChoice;
+  parallel_tool_calls?: boolean;
+  response_format?: RequestyResponseFormat;
+  reasoning?: RequestyReasoning;
+  function_handler?: ChatFunctionHandler;
+}
+
+export type Requesty = true | RequestyChat;

--- a/component/src/types/requestyInternal.ts
+++ b/component/src/types/requestyInternal.ts
@@ -1,0 +1,45 @@
+import {RequestyReasoning, RequestyResponseFormat, RequestyTool, RequestyToolChoice} from './requesty';
+
+export type RequestyToolCall = {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+export type RequestyContent = {
+  type: 'text' | 'image_url' | 'input_audio';
+  text?: string;
+  image_url?: {
+    url: string;
+  };
+  input_audio?: {
+    data: string;
+    format: 'wav' | 'mp3';
+  };
+};
+
+export type RequestyMessage = {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string | RequestyContent[] | null;
+  tool_calls?: RequestyToolCall[];
+  tool_call_id?: string;
+  name?: string;
+};
+
+export type RequestyRequestBody = {
+  model: string;
+  models?: string[];
+  messages: RequestyMessage[];
+  tools?: RequestyTool[];
+  tool_choice?: RequestyToolChoice;
+  parallel_tool_calls?: boolean;
+  response_format?: RequestyResponseFormat;
+  reasoning?: RequestyReasoning;
+  stream?: boolean;
+  max_tokens?: number;
+  max_completion_tokens?: number;
+  stop?: string | string[];
+};

--- a/component/src/types/requestyResult.ts
+++ b/component/src/types/requestyResult.ts
@@ -1,0 +1,65 @@
+import {RequestyToolCall} from './requestyInternal';
+
+export type RequestyImageContent = {
+  type: 'image_url';
+  image_url: {
+    url: string;
+  };
+};
+
+export type RequestyResponse = {
+  id: string;
+  object: 'chat.completion';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: {
+      role: 'assistant';
+      content: string | null;
+      tool_calls?: RequestyToolCall[];
+      images?: RequestyImageContent[];
+    };
+    finish_reason: string;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+  error?: {
+    message: string;
+    type: string;
+    code?: string;
+  };
+};
+
+export type RequestyStreamEvent = {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: 'assistant';
+      content?: string;
+      images?: RequestyImageContent[];
+      tool_calls?: RequestyToolCall[];
+    };
+    finish_reason?: string;
+  }>;
+  message?: {
+    role: 'assistant';
+    content: string | null;
+    tool_calls?: RequestyToolCall[];
+    images?: RequestyImageContent[];
+  };
+  error?: {
+    message: string;
+    type: string;
+    code?: string;
+  };
+};
+
+export type RequestyAPIResult = RequestyResponse | RequestyStreamEvent;

--- a/website/docs/docs/directConnection/Requesty.mdx
+++ b/website/docs/docs/directConnection/Requesty.mdx
@@ -1,0 +1,204 @@
+---
+sidebar_position: 23
+---
+
+# Requesty
+
+# <span className="direct-service-title">Requesty</span>
+
+Properties used to connect to [Requesty](https://requesty.ai/).
+
+### `requesty` {#requesty}
+
+- Type: `true` | \{<br />
+  &nbsp;&nbsp;&nbsp;&nbsp; `model?: string`, <br />
+  &nbsp;&nbsp;&nbsp;&nbsp; `max_tokens?: number`, <br />
+  &nbsp;&nbsp;&nbsp;&nbsp; `system_prompt?: string`, <br />
+  &nbsp;&nbsp;&nbsp;&nbsp; [`tools?: RequestyTool[]`](#RequestyTool), <br />
+  &nbsp;&nbsp;&nbsp;&nbsp; [`function_handler?: FunctionHandler`](#FunctionHandler) <br />
+  \}
+- Default: _\{model: "openai/gpt-4o"\}_
+
+import ContainersKeyToggleChatFunction from '@site/src/components/table/containersKeyToggleChatFunction';
+import ContainersKeyToggle from '@site/src/components/table/containersKeyToggle';
+import ComponentContainer from '@site/src/components/table/componentContainer';
+import DeepChatBrowser from '@site/src/components/table/deepChatBrowser';
+import LineBreak from '@site/src/components/markdown/lineBreak';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+<BrowserOnly>{() => require('@site/src/components/nav/autoNavToggle').readdAutoNavShadowToggle()}</BrowserOnly>
+
+Connect to Requesty's [Chat Completion API](https://docs.requesty.ai/). Requesty is an OpenAI-compatible LLM gateway, so models are
+referenced using the `provider/model` naming convention. You can set this property to _true_ or configure it using an object:<br />
+`model` is the name of the model to be used by the API (e.g., "openai/gpt-4o-mini"). <br />
+`max_tokens` limits the maximum number of tokens in the generated response. <br />
+`system_prompt` provides behavioral context and instructions to the model. <br />
+[`tools`](#RequestyTool) defines available function declarations for the model to call. <br />
+[`function_handler`](#FunctionHandler) enables function calling capabilities for tool use. <br />
+
+#### Example
+
+<ContainersKeyToggle>
+  <ComponentContainer>
+    <DeepChatBrowser
+      style={{borderRadius: '8px'}}
+      directConnection={{
+        requesty: {
+          key: 'placeholder key',
+          model: 'openai/gpt-4o-mini',
+        },
+      }}
+    ></DeepChatBrowser>
+  </ComponentContainer>
+  <ComponentContainer>
+    <DeepChatBrowser
+      style={{borderRadius: '8px'}}
+      directConnection={{
+        requesty: {
+          model: 'openai/gpt-4o-mini',
+        },
+      }}
+    ></DeepChatBrowser>
+  </ComponentContainer>
+</ContainersKeyToggle>
+
+<Tabs>
+<TabItem value="js" label="Sample code">
+
+```html
+<deep-chat
+  directConnection='{
+    "requesty": {
+      "key": "placeholder key",
+      "model": "openai/gpt-4o-mini"
+    }
+  }'
+></deep-chat>
+```
+
+</TabItem>
+<TabItem value="py" label="Full code">
+
+```html
+<!-- This example is for Vanilla JS and should be tailored to your framework (see Examples) -->
+
+<deep-chat
+  directConnection='{
+    "requesty": {
+      "key": "placeholder key",
+      "model": "openai/gpt-4o-mini"
+    }
+  }'
+  style="border-radius: 8px"
+></deep-chat>
+```
+
+</TabItem>
+</Tabs>
+
+<LineBreak></LineBreak>
+
+:::info
+Use [`stream`](/docs/connect#Stream) to stream the AI responses.
+:::
+
+<LineBreak></LineBreak>
+
+#### Vision Example
+
+Upload images alongside your text prompts for visual understanding. You must use a model with vision capabilities.
+
+<ContainersKeyToggle>
+  <ComponentContainer>
+    <DeepChatBrowser
+      style={{borderRadius: '8px'}}
+      directConnection={{
+        requesty: {
+          key: 'placeholder key',
+          model: 'openai/gpt-4o',
+        },
+      }}
+      images={true}
+      camera={true}
+      textInput={{styles: {container: {width: '77%'}}}}
+    ></DeepChatBrowser>
+  </ComponentContainer>
+  <ComponentContainer>
+    <DeepChatBrowser
+      style={{borderRadius: '8px'}}
+      directConnection={{
+        requesty: {
+          model: 'openai/gpt-4o',
+        },
+      }}
+      images={true}
+      camera={true}
+      textInput={{styles: {container: {width: '77%'}}}}
+    ></DeepChatBrowser>
+  </ComponentContainer>
+</ContainersKeyToggle>
+
+<Tabs>
+<TabItem value="js" label="Sample code">
+
+```html
+<deep-chat
+  directConnection='{
+    "requesty": {
+      "key": "placeholder key",
+      "model": "openai/gpt-4o"
+    }
+  }'
+  images="true"
+  camera="true"
+></deep-chat>
+```
+
+</TabItem>
+<TabItem value="py" label="Full code">
+
+```html
+<!-- This example is for Vanilla JS and should be tailored to your framework (see Examples) -->
+
+<deep-chat
+  directConnection='{
+    "requesty": {
+      "key": "placeholder key",
+      "model": "openai/gpt-4o"
+    }
+  }'
+  images="true"
+  camera="true"
+  style="border-radius: 8px"
+  textInput='{"styles": {"container": {"width": "77%"}}}'
+></deep-chat>
+```
+
+</TabItem>
+</Tabs>
+
+<LineBreak></LineBreak>
+
+:::tip
+When sending images we advise you to set [`maxMessages`](/docs/connect#requestBodyLimits) to 1 to send less data and reduce costs.
+:::
+
+<LineBreak></LineBreak>
+
+## Types
+
+Objects used for the `requesty` property:
+
+#### `RequestyTool` {#RequestyTool}
+
+- Type: \{`type: 'function'`, `function: {name: string, description: string, parameters: object}`\}
+
+Defines a function that the model is able to call. See the [Function calling](#FunctionHandler) section for more.
+
+#### `FunctionHandler` {#FunctionHandler}
+
+- Type: (`functionsDetails: FunctionsDetails`) => `{response: string}[]` | `{text: string}`
+
+The function used to handle the tool calls requested by the model. See [`tools`](#RequestyTool) for the related configuration.

--- a/website/docs/docs/directConnection/directConnection.mdx
+++ b/website/docs/docs/directConnection/directConnection.mdx
@@ -42,6 +42,7 @@ property to connect to your server. Read more about this in [`Connect`](../conne
   &nbsp;&nbsp;&nbsp;&nbsp; `openWebUI?:` \{[`OpenWebUI`](/docs/directConnection/OpenWebUI#openWebUI), [`APIKey`](#APIKey)\}, <br />
   &nbsp;&nbsp;&nbsp;&nbsp; `perplexity?:` \{[`Perplexity`](/docs/directConnection/Perplexity#perplexity), [`APIKey`](#APIKey)\}, <br />
   &nbsp;&nbsp;&nbsp;&nbsp; `qwen?:` \{[`Qwen`](/docs/directConnection/Qwen#qwen), [`APIKey`](#APIKey)\}, <br />
+  &nbsp;&nbsp;&nbsp;&nbsp; `requesty?:` \{[`Requesty`](/docs/directConnection/Requesty#requesty), [`APIKey`](#APIKey)\}, <br />
   &nbsp;&nbsp;&nbsp;&nbsp; `stabilityAI?:` \{[`StabilityAI`](/docs/directConnection/StabilityAI#stabilityAI), [`APIKey`](#APIKey)\}, <br />
   &nbsp;&nbsp;&nbsp;&nbsp; `together?:` \{[`Together`](/docs/directConnection/Together#together), [`APIKey`](#APIKey)\}, <br />
   &nbsp;&nbsp;&nbsp;&nbsp; `x?:` \{[`X`](/docs/directConnection/X#x), [`APIKey`](#APIKey)\} <br />


### PR DESCRIPTION
This adds a dedicated `requesty` direct connection provider, mirroring the existing OpenRouter service as closely as possible.

Changes:
* `component/src/services/requesty/requestyIO.ts`: new `RequestyIO` service class, a 1:1 mirror of `OpenRouterIO`, pointing at `https://router.requesty.ai/v1/chat/completions`.
* `component/src/services/requesty/utils/requestyUtils.ts`: headers and key verification (verifies against `GET https://router.requesty.ai/v1/models`), mirroring the OpenRouter utils.
* `component/src/types/requesty.ts`, `requestyInternal.ts`, `requestyResult.ts`: the public `Requesty` config type plus internal request and result types, mirroring the OpenRouter type files.
* `component/src/services/serviceIOFactory.ts`: import `RequestyIO` and add the `if (directConnection.requesty) { return new RequestyIO(deepChat); }` branch next to the OpenRouter one.
* `component/src/types/directConnection.ts`: import `Requesty` and add `requesty?: Requesty & APIKey;` to `DirectConnection`.
* `website/docs/docs/directConnection/Requesty.mdx` and `directConnection.mdx`: provider documentation page plus the entry in the direct connection list.

Requesty is an OpenAI-compatible LLM gateway, so the request and response shapes match OpenRouter and the same handling is reused. Model naming is `provider/model`, the same convention as OpenRouter (for example `openai/gpt-4o`, `anthropic/claude-sonnet-4-5`).

Verification: I ran `npx tsc --noEmit` for the component package and it reports no errors with these changes. I also tested the endpoint live: `GET https://router.requesty.ai/v1/models` returned 200 (572 models), and a chat completion with `openai/gpt-4o-mini` against `https://router.requesty.ai/v1/chat/completions` returned 200.

Docs: https://requesty.ai , https://docs.requesty.ai , https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
