### PR TITLE
Support MiniMax image and video inputs

### DIFF
--- a/component/src/services/miniMax/miniMaxIO.ts
+++ b/component/src/services/miniMax/miniMaxIO.ts
@@ -1,7 +1,7 @@
 import {AUTHENTICATION_ERROR_PREFIX, INVALID_REQUEST_ERROR_PREFIX, OBJECT} from '../utils/serviceConstants';
 import {MINI_MAX_BUILD_KEY_VERIFICATION_DETAILS, MINI_MAX_BUILD_HEADERS} from './utils/miniMaxUtils';
-import {DEEP_COPY, ERROR, ROLE, TEXT} from '../../utils/consts/messageConstants';
-import {MiniMaxRequestBody, MiniMaxMessage} from '../../types/miniMaxInternal';
+import {DEEP_COPY, ERROR, FILES, IMAGE, ROLE, SRC, TEXT, TYPE} from '../../utils/consts/messageConstants';
+import {MiniMaxContent, MiniMaxRequestBody, MiniMaxMessage} from '../../types/miniMaxInternal';
 import {DirectConnection} from '../../types/directConnection';
 import {MessageContentI} from '../../types/messagesInternal';
 import {Messages} from '../../views/chat/messages/messages';
@@ -12,11 +12,11 @@ import {MiniMax} from '../../types/miniMax';
 import {APIKey} from '../../types/APIKey';
 import {DeepChat} from '../../deepChat';
 
-// https://www.minimax.io/platform/document/ChatCompletion%20v2?key=66701d281d57f38758d581d0#QklxsNSbaf6kM4j6wjO5eEek
+// https://platform.minimax.io/docs/api-reference/text-chat-openai
 export class MiniMaxIO extends DirectServiceIO {
   override insertKeyPlaceholderText = this.genereteAPIKeyName('MiniMax');
   override keyHelpUrl = 'https://www.minimaxi.com';
-  url = 'https://api.minimax.io/v1/text/chatcompletion_v2';
+  url = 'https://api.minimax.io/v1/chat/completions';
   permittedErrorPrefixes = [INVALID_REQUEST_ERROR_PREFIX, AUTHENTICATION_ERROR_PREFIX, 'insufficient balance'];
 
   constructor(deepChat: DeepChat) {
@@ -28,11 +28,28 @@ export class MiniMaxIO extends DirectServiceIO {
     this.rawBody.model ??= 'MiniMax-M1';
   }
 
+  private static getContent(message: MessageContentI): MiniMaxMessage['content'] {
+    const content: MiniMaxContent[] = [];
+    if (message[TEXT] && message[TEXT].trim().length > 0) content.push({[TYPE]: TEXT, [TEXT]: message[TEXT]});
+    message[FILES]?.forEach((file) => {
+      const url = file[SRC];
+      if (!url) return;
+      const mimeType = file.ref?.type || url.match(/^data:([^;,]+)/)?.[1] || '';
+      const fileNameOrUrl = `${file.name || ''} ${url}`;
+      if (file[TYPE] === IMAGE || mimeType.startsWith('image/')) {
+        content.push({[TYPE]: 'image_url', image_url: {url}});
+      } else if (mimeType.startsWith('video/') || /\.(mp4|avi|mov|mkv)(?:[?#]|$)/i.test(fileNameOrUrl)) {
+        content.push({[TYPE]: 'video_url', video_url: {url}});
+      }
+    });
+    return content.length > 0 ? content : message[TEXT] || '';
+  }
+
   private preprocessBody(body: MiniMaxRequestBody, pMessages: MessageContentI[]) {
     const bodyCopy = DEEP_COPY(body) as MiniMaxRequestBody;
     const processedMessages = this.processMessages(pMessages).map((message) => {
       return {
-        content: message[TEXT] || '',
+        content: MiniMaxIO.getContent(message),
         [ROLE]: DirectServiceIO.getRoleViaUser(message[ROLE]),
       } as MiniMaxMessage;
     });

--- a/component/src/types/miniMaxInternal.ts
+++ b/component/src/types/miniMaxInternal.ts
@@ -1,6 +1,11 @@
+export type MiniMaxContent =
+  | {type: 'text'; text: string}
+  | {type: 'image_url'; image_url: {url: string}}
+  | {type: 'video_url'; video_url: {url: string}};
+
 export interface MiniMaxMessage {
   role: 'system' | 'user' | 'assistant';
-  content: string;
+  content: string | MiniMaxContent[];
 }
 
 export interface MiniMaxRequestBody {

--- a/component/src/views/chat/messages/messages.ts
+++ b/component/src/views/chat/messages/messages.ts
@@ -420,7 +420,8 @@ export class Messages extends MessagesBase {
     return Promise.all<MessageFile>(
       (filesData || []).map((fileData) => {
         return new Promise((resolve) => {
-          if (!fileData[TYPE] || fileData[TYPE] === ANY) {
+          const isVideo = fileData[FILE].type.startsWith('video/');
+          if ((!fileData[TYPE] || fileData[TYPE] === ANY) && !isVideo) {
             const name = fileData[FILE].name || FILE;
             resolve({name, [TYPE]: ANY, ref: fileData[FILE]});
           } else {


### PR DESCRIPTION
Reason: Enable MiniMax multimodal chat requests to preserve and send image and video attachments.

This change moves MiniMax chat requests to the OpenAI-compatible chat completions endpoint and builds structured content parts for text, image, and video inputs. It also preserves uploaded video data URLs so they can reach the request mapper.

Checks:

- `npm run lint -- --no-warn-ignored src/services/miniMax/miniMaxIO.ts src/types/miniMaxInternal.ts src/views/chat/messages/messages.ts`
- `npx tsc --noEmit`
- `npm run build`
